### PR TITLE
handle case if modelType isn't in modelParams

### DIFF
--- a/R/Estimator.R
+++ b/R/Estimator.R
@@ -317,6 +317,9 @@ predictDeepEstimator <- function(plpModel,
     model <- torch$load(file.path(plpModel$model,
                                   "DeepEstimatorModel.pt"),                        
                         map_location = "cpu")
+    if (is.null(model$model_parameters$model_type)) {
+      model$model_parameters$model_type <- plpModel$modelDesign$modelSettings$modelType
+    }
     estimator <-
       createEstimator(modelParameters =
                       snakeCaseToCamelCaseNames(model$model_parameters),


### PR DESCRIPTION
For backwards compatibility, when loading a model developed with a previous version it might not have `model_type` accessible in the `model_parameters` when creating an estimator.  But it is in the `modelDesign` so I make sure to get it from there in these cases.

