### PR TITLE
add train-validation-split

### DIFF
--- a/R/Estimator.R
+++ b/R/Estimator.R
@@ -43,6 +43,8 @@
 #' @param accumulationSteps how many steps to accumulate gradients before
 #' updating weights, can also be a function that is evaluated during runtime
 #' @param seed seed to initialize weights of model with
+#' @param trainValidationSplit if TRUE, perform a train-validation split for 
+#' model selection instead of cross validation
 #' @export
 setEstimator <- function(
     learningRate = "auto",
@@ -63,7 +65,8 @@ setEstimator <- function(
     compile = FALSE,
     metric = "auc",
     accumulationSteps = NULL,
-    seed = NULL) {
+    seed = NULL,
+    trainValidationSplit = FALSE) {
   checkIsClass(learningRate, c("numeric", "character"))
   if (inherits(learningRate, "character") && learningRate != "auto") {
     stop(paste0('Learning rate should be either a numeric or "auto",
@@ -79,6 +82,7 @@ setEstimator <- function(
   checkIsClass(compile, "logical")
   checkIsClass(metric, c("character", "list"))
   checkIsClass(seed, c("numeric", "integer", "NULL"))
+  checkIsClass(trainValidationSplit, "logical")
   
   if (!is.null(accumulationSteps) && !is.function(accumulationSteps)) {
     checkHigher(accumulationSteps, 0)
@@ -109,6 +113,9 @@ setEstimator <- function(
     accumulationSteps = accumulationSteps,
     seed = seed[1]
   )
+  if (!is.null(trainValidationSplit)) {
+    estimatorSettings$trainValidationSplit <- trainValidationSplit
+  }
 
   optimizer <- rlang::enquo(optimizer)
   estimatorSettings$optimizer <- function() rlang::eval_tidy(optimizer)
@@ -421,7 +428,11 @@ gridCvDeep <- function(mappedData,
 
   # get best CV prediction
   cvPrediction <- hyperparameterResults[[indexOfMax]]$prediction
-  cvPrediction$evaluationType <- "CV"
+  if (modelSettings$estimatorSettings$trainValidationSplit) {
+    cvPrediction$evaluationType <- "Validation"
+  } else {
+    cvPrediction$evaluationType <- "CV"
+  }
 
   ParallelLogger::logInfo("Training final model using optimal parameters")
   trainPrediction <- trainFinalModel(dataset,
@@ -606,6 +617,12 @@ doCrossValidationImpl <- function(dataset,
 
   fold <- labels$index
   ParallelLogger::logInfo(paste0("Max fold: ", max(fold)))
+  if (isTRUE(modelSettings$estimatorSettings$trainValidationSplit)) {
+    ParallelLogger::logInfo("Using train-validation split instead of cross validation:
+      training on folds != max(folds), and validating on fold == max(folds)")
+    fold <- ifelse(fold == max(fold), 1, 0)
+    labels$index <- fold
+  }
   learnRates <- list()
   prediction <- NULL
   path <- system.file("python", package = "DeepPatientLevelPrediction")
@@ -619,11 +636,13 @@ doCrossValidationImpl <- function(dataset,
       indices =
         as.integer(which(fold != i) - 1)
     )
+    ParallelLogger::logInfo("Training dataset size: ", length(trainDataset))
 
     # -1 for python 0-based indexing
     testDataset <- torch$utils$data$Subset(dataset,
                                            indices =
                                              as.integer(which(fold == i) - 1))
+    ParallelLogger::logInfo("Validation dataset size: ", length(testDataset))
     estimator <- createEstimator(currentParameters)
     fit_estimator(estimator, trainDataset, testDataset)
 

--- a/man/setEstimator.Rd
+++ b/man/setEstimator.Rd
@@ -18,7 +18,8 @@ setEstimator(
   compile = FALSE,
   metric = "auc",
   accumulationSteps = NULL,
-  seed = NULL
+  seed = NULL,
+  trainValidationSplit = FALSE
 )
 }
 \arguments{
@@ -55,6 +56,9 @@ outputs a score.}
 updating weights, can also be a function that is evaluated during runtime}
 
 \item{seed}{seed to initialize weights of model with}
+
+\item{trainValidationSplit}{if TRUE, perform a train-validation split for 
+model selection instead of cross validation}
 }
 \description{
 creates settings for the Estimator, which takes a model and trains it


### PR DESCRIPTION
Added a setting to `setEstimator` called `trainValidationSplit`, when this is true it does a simple train-validation split instead of cross validation for model selection/hyperparameter tuning. This can save a lot of computation when you have large data, and when you have large data cross validation is also not really needed as much as with small data. I've also changed the `evaluationType` for this case to `Validation` instead of `CV`. 

Seems to work, still have to add tests.