### PR TITLE
fix dropping of last batch for small batch sizes

### DIFF
--- a/inst/python/Estimator.py
+++ b/inst/python/Estimator.py
@@ -112,7 +112,7 @@ class Estimator:
             sampler=BatchSampler(
                 sampler=RandomSampler(dataset),
                 batch_size=self.batch_size,
-                drop_last=True,
+                drop_last=True if len(dataset) > self.batch_size else False,
             ),
             pin_memory=True,
         )


### PR DESCRIPTION
Don't drop last batch if less than `batch_size` when data is less than `batch_size`.