### PR TITLE
docs(ci,deps): uv+py3.12 docs, torch range update, and py3.10 lane

### DIFF
--- a/.github/workflows/R_CDM_check_hades.yaml
+++ b/.github/workflows/R_CDM_check_hades.yaml
@@ -85,6 +85,7 @@ jobs:
           needs: check
 
       - name: setup r-reticulate venv
+        shell: bash
         run: |
           uv pip install polars tqdm pyarrow duckdb nvidia-ml-py numpy
           if [ "${{ matrix.config.torch }}" = "latest" ]; then

--- a/.github/workflows/R_CDM_check_hades.yaml
+++ b/.github/workflows/R_CDM_check_hades.yaml
@@ -59,13 +59,13 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.12'
 
       - name: Install the latest version of uv
         uses: astral-sh/setup-uv@v4
         with:
           version: "latest"
-          python-version: "3.11"
+          python-version: "3.12"
         
       - name: Install system requirements
         if: runner.os == 'Linux'
@@ -85,7 +85,7 @@ jobs:
 
       - name: setup r-reticulate venv
         run: | 
-          uv pip install polars tqdm pyarrow duckdb pynvml numpy
+          uv pip install polars tqdm pyarrow duckdb nvidia-ml-py numpy
           uv pip install torch --index https://download.pytorch.org/whl/cpu/
 
       - uses: r-lib/actions/check-r-package@v2

--- a/.github/workflows/R_CDM_check_hades.yaml
+++ b/.github/workflows/R_CDM_check_hades.yaml
@@ -14,15 +14,16 @@ jobs:
   R-CMD-check:
     runs-on: ${{ matrix.config.os }}
 
-    name: ${{ matrix.config.os }} (${{ matrix.config.r }})
+    name: ${{ matrix.config.os }} (R-${{ matrix.config.r }}, Py-${{ matrix.config.python }}, Torch-${{ matrix.config.torch }})
 
     strategy:
       fail-fast: false
       matrix:
         config:
-          - {os: windows-latest, r: 'release'}
-          - {os: macOS-latest, r: 'release'}
-          - {os: ubuntu-24.04, r: 'release', rspm: "https://packagemanager.rstudio.com/cran/__linux__/noble/latest"}
+          - {os: windows-latest, r: 'release', python: '3.12', torch: '2.10.0'}
+          - {os: macOS-latest, r: 'release', python: '3.12', torch: '2.10.0'}
+          - {os: ubuntu-24.04, r: 'release', python: '3.12', torch: '2.10.0', rspm: "https://packagemanager.rstudio.com/cran/__linux__/noble/latest"}
+          - {os: ubuntu-24.04, r: 'release', python: '3.10', torch: 'latest', rspm: "https://packagemanager.rstudio.com/cran/__linux__/noble/latest"}
 
     env:
       GITHUB_PAT: ${{ secrets.GH_TOKEN }}
@@ -59,13 +60,13 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: ${{ matrix.config.python }}
 
       - name: Install the latest version of uv
         uses: astral-sh/setup-uv@v4
         with:
           version: "latest"
-          python-version: "3.12"
+          python-version: ${{ matrix.config.python }}
         
       - name: Install system requirements
         if: runner.os == 'Linux'
@@ -84,9 +85,13 @@ jobs:
           needs: check
 
       - name: setup r-reticulate venv
-        run: | 
+        run: |
           uv pip install polars tqdm pyarrow duckdb nvidia-ml-py numpy
-          uv pip install torch --index https://download.pytorch.org/whl/cpu/
+          if [ "${{ matrix.config.torch }}" = "latest" ]; then
+            uv pip install torch --index https://download.pytorch.org/whl/cpu/
+          else
+            uv pip install "torch==${{ matrix.config.torch }}" --index https://download.pytorch.org/whl/cpu/
+          fi
 
       - uses: r-lib/actions/check-r-package@v2
         with:

--- a/.github/workflows/R_CMD_check_main_weekly.yaml
+++ b/.github/workflows/R_CMD_check_main_weekly.yaml
@@ -33,13 +33,13 @@ jobs:
           
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.11' 
+          python-version: '3.12'
 
       - name: Install the latest version of uv
         uses: astral-sh/setup-uv@v4
         with:
           version: "latest"
-          python-version: "3.11"
+          python-version: "3.12"
       
       - uses: r-lib/actions/setup-tinytex@v2
 
@@ -52,7 +52,7 @@ jobs:
 
       - name: setup r-reticulate venv
         run: | 
-          uv pip install polars tqdm pyarrow duckdb pynvml numpy
+          uv pip install polars tqdm pyarrow duckdb nvidia-ml-py numpy
           uv pip install torch --index https://download.pytorch.org/whl/cpu/
 
       - uses: r-lib/actions/check-r-package@v2

--- a/.github/workflows/R_CMD_check_main_weekly.yaml
+++ b/.github/workflows/R_CMD_check_main_weekly.yaml
@@ -51,9 +51,9 @@ jobs:
           needs: check
 
       - name: setup r-reticulate venv
-        run: | 
+        run: |
           uv pip install polars tqdm pyarrow duckdb nvidia-ml-py numpy
-          uv pip install torch --index https://download.pytorch.org/whl/cpu/
+          uv pip install "torch==2.10.0" --index https://download.pytorch.org/whl/cpu/
 
       - uses: r-lib/actions/check-r-package@v2
         with:

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,8 @@ DeepPatientLevelPrediction 2.2.0.9999
 - [Internal] Switch to `nvidia-ml-py` instead of `pynvml` due to the latter being deprecated
 - [Docs] Update installation guide to recommend `uv` and Python 3.12
 - [CI] Use Python 3.12 in GitHub Actions checks
+- [Internal] Relax torch requirement to `torch>=2.6,<3`
+- [CI] Pin stable CI lanes to `torch==2.10.0` and add a Python 3.10 compatibility lane using latest torch
 
 DeepPatientLevelPrediction 2.2.0
 ======================

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 DeepPatientLevelPrediction 2.2.0.9999
 ======================
 - [Internal] Switch to `nvidia-ml-py` instead of `pynvml` due to the latter being deprecated
+- [Docs] Update installation guide to recommend `uv` and Python 3.12
+- [CI] Use Python 3.12 in GitHub Actions checks
 
 DeepPatientLevelPrediction 2.2.0
 ======================

--- a/R/DeepPatientLevelPrediction.R
+++ b/R/DeepPatientLevelPrediction.R
@@ -43,7 +43,7 @@ torch <- NULL
 
 .onLoad <- function(libname, pkgname) {
   reticulate::py_require(c(
-    "polars>=1.31.0", "pyarrow", "duckdb", "torch<=2.6.0", "tqdm",
+    "polars>=1.31.0", "pyarrow", "duckdb", "torch>=2.6,<3", "tqdm",
     "nvidia-ml-py"
   ))
   torch <<- reticulate::import("torch", delay_load = TRUE)

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Features
 
 Technology
 ==========
-DeepPatientLevelPrediction is an R package. It uses [torch in R](https://torch.mlverse.org/) to build deep learning models without using python.
+DeepPatientLevelPrediction is an R package. It uses Python [PyTorch](https://pytorch.org/) through [reticulate](https://rstudio.github.io/reticulate/) for deep learning model training and inference.
 
 System Requirements
 ===================
@@ -59,4 +59,3 @@ DeepPatientLevelPrediction is licensed under Apache License 2.0
 Development
 ===========
 DeepPatientLevelPrediction is being developed in R Studio.
-

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,13 +1,29 @@
 library(testthat)
-library(DeepPatientLevelPrediction)
 
-withCallingHandlers({
-  test_check("DeepPatientLevelPrediction")
-}, error = function(e) {
-  traceback()
-  message(e)
-  if (!is.null(reticulate::py_last_error())) {
-    reticulate::py_last_error()
-  }
-  stop(e)
-})
+run_tests <- function() {
+  # Keep torch.compile/inductor artifacts inside this check temp dir and clean up.
+  torchinductor_cache_dir <- file.path(
+    tempdir(),
+    sprintf("torchinductor_cache_%s", Sys.getpid())
+  )
+  Sys.setenv(TORCHINDUCTOR_CACHE_DIR = torchinductor_cache_dir)
+  on.exit({
+    unlink(torchinductor_cache_dir, recursive = TRUE, force = TRUE)
+    Sys.unsetenv("TORCHINDUCTOR_CACHE_DIR")
+  }, add = TRUE)
+
+  library(DeepPatientLevelPrediction)
+
+  withCallingHandlers({
+    test_check("DeepPatientLevelPrediction")
+  }, error = function(e) {
+    traceback()
+    message(e)
+    if (!is.null(reticulate::py_last_error())) {
+      reticulate::py_last_error()
+    }
+    stop(e)
+  })
+}
+
+run_tests()

--- a/vignettes/Installing.Rmd
+++ b/vignettes/Installing.Rmd
@@ -38,7 +38,7 @@ This vignette describes how you need to install the Observational Health Data Sc
 Under Windows the OHDSI Deep Patient Level Prediction (DeepPLP) package requires installing:
 
 -   R (<https://cran.r-project.org/> ) - (R \>= 4.0.0, but latest is recommended)
--   Python - The package is tested with python 3.10, but \>= 3.8 should work
+-   Python - Recommend Python 3.12. Python \>= 3.10 is supported
 -   Rstudio (<https://www.rstudio.com/> )
 -   Java (<http://www.java.com> )
 -   RTools (<https://cran.r-project.org/bin/windows/Rtools/>)
@@ -48,7 +48,7 @@ Under Windows the OHDSI Deep Patient Level Prediction (DeepPLP) package requires
 Under Mac and Linux the OHDSI DeepPLP package requires installing:
 
 -   R (<https://cran.r-project.org/> ) - (R \>= 4.0.0, but latest is recommended)
--   Python - The package is tested with python 3.10, but \>= 3.8 should work
+-   Python - Recommend Python 3.12. Python \>= 3.10 is supported
 -   Rstudio (<https://www.rstudio.com/> )
 -   Java (<http://www.java.com> )
 -   Xcode command line tools(run in terminal: xcode-select --install) [MAC USERS ONLY]
@@ -63,28 +63,40 @@ Note that the latest develop branch could contain bugs, please report them to us
 
 ## Installing Python environment
 
-Since the package uses `pytorch` through `reticulate` a working python installation is required. The package is tested with python 3.10. To install python an easy way is to use miniconda through `reticulate`:
+Since the package uses `pytorch` through `reticulate`, a working Python installation is required. We recommend using `uv` with Python 3.12.
+
+Install `uv` by following the official instructions:
+
+<https://docs.astral.sh/uv/getting-started/installation/>
+
+Then create a local virtual environment for this project:
+
+```bash
+uv python install 3.12
+uv venv --python 3.12
+```
+
+Tell `reticulate` to use that interpreter by setting `RETICULATE_PYTHON` in `.Renviron`.
+
+For Linux/macOS:
+
+```
+RETICULATE_PYTHON="/path/to/project/.venv/bin/python"
+```
+
+For Windows:
+
+```
+RETICULATE_PYTHON="C:/path/to/project/.venv/Scripts/python.exe"
+```
+
+Then restart your R session. You can verify the active interpreter with:
 
 ```{r, echo = TRUE, message = FALSE, warning = FALSE,tidy=FALSE,eval=FALSE}
-install.packages('reticulate')
-reticulate::install_miniconda()
+reticulate::py_config()
 ```
 
-By default `install_minconda()` creates an environment `r-reticulate` with `python 3.9`. To use instead `python 3.10` we can do:
-
-```{r, echo = TRUE, message = FALSE, warning = FALSE,tidy=FALSE,eval=FALSE}
-reticulate::conda_install(envname = 'r-reticulate', packages=c('python=3.10'))
-```
-
-If reticulate is having issues finding the conda installation you can use the function `reticulate::miniconda_path()` to find the default installation location for your miniconda installation. Then you can force reticulate to use the newly generated environment by setting the environment variable `RETICULATE_PYTHON` to point to the python binary in the environment. For example by adding the following to the `.Renviron` file:
-
-```         
-RETICULATE_PYTHON="/path/to/miniconda/envs/r-reticulate/python/bin"
-```
-
-Then you need to restart you R session. To verify that `reticulate` finds the correct version. You can call `reticulate::py_config()`. 
-
-Once you have a working python environment that reticulate can locate you can install `DeepPatientLevelPrediction`. If you want to use a specific python environment you can set the environment variable `RETICULATE_PYTHON` to point to the python executable of that environment in your `.Renviron` file. You need to do this before installing `DeepPatientLevelPrediction`.
+Python 3.9 is end-of-life and should not be used. Python 3.10 is still supported, but Python 3.12 is recommended.
 
 ## Installing DeepPatientLevelPrediction using remotes
 


### PR DESCRIPTION
## Summary
- recommend uv and Python 3.12 in installation docs
- remove outdated miniconda guidance from the installation vignette
- align README technology section with current reticulate + Python PyTorch backend
- switch CI setup to nvidia-ml-py (replacement for deprecated pynvml)
- relax runtime torch requirement from torch<=2.6.0 to torch>=2.6,<3
- pin stable CI lanes to torch==2.10.0
- add a Python 3.10 compatibility lane using latest torch

## Notes
- docs now explicitly recommend Python 3.12 while retaining support for Python >=3.10
- weekly workflow remains pinned for reproducibility; compatibility lane is in main R-CMD-check workflow

## Related
- Closes #134
- Closes #128
