### PR TITLE
fix: stabilize temporal feature ordering

### DIFF
--- a/inst/python/Dataset.py
+++ b/inst/python/Dataset.py
@@ -321,14 +321,14 @@ def aggregate_sequences(
             else pl.col("columnId")
         ).alias("feature_ids"),
         (
-            pl.col("covariateValue").sort_by("timeId")
+            pl.col("covariateValue").sort_by(["timeId", "columnId"])
             if with_time
             else pl.col("covariateValue")
         ).alias("feature_values"),
     ]
     if with_time:
         data = data.with_columns(pl.col("timeId").fill_null(0).cast(pl.Int32))
-        aggs.append(pl.col("timeId").sort_by("timeId").alias("time_ids"))
+        aggs.append(pl.col("timeId").sort_by(["timeId", "columnId"]).alias("time_ids"))
     grouped = data.group_by("rowId").agg(*aggs)
     all_rows = (
         data.select("rowId").unique().with_columns((pl.col("rowId")).alias("rowId"))

--- a/vignettes/FirstModel.Rmd
+++ b/vignettes/FirstModel.Rmd
@@ -133,7 +133,8 @@ plpResults <- PatientLevelPrediction::runPlp(plpData = plpData,
                modelSettings = modelSettings,
                analysisId = 'ResNet',
                analysisName = 'Testing DeepPlp',
-               populationSettings = populationSettings
+               populationSettings = populationSettings,
+               saveDirectory = "ResNet"
                                                       )
 ```
 


### PR DESCRIPTION
## Summary
- sort temporal feature ids, values, and time ids with the same keys to keep feature values aligned under Polars 1.40
- add the required `saveDirectory` argument to the first-model vignette `runPlp()` example

Fixes #174
Fixes #173

## Testing
- `RETICULATE_PYTHON="$PWD/.venv/bin/python" RETICULATE_USE_MANAGED_VENV=no Rscript -e 'pkgload::load_all(); testthat::test_file("tests/testthat/test-Dataset.R")'`\n- `git diff --check`