### PR TITLE
docs: refresh examples for current API

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ DeepPatientLevelPrediction
 Introduction
 ============
 
-DeepPatientLevelPrediction is an R package for building and validating deep learning patient-level predictive models using data in the OMOP Common Data Model format and OHDSI PatientLevelPrediction framework.  
+DeepPatientLevelPrediction is an R package for building and validating deep learning patient-level predictive models using data in the OMOP Common Data Model format and OHDSI PatientLevelPrediction framework.
 
 Reps JM, Schuemie MJ, Suchard MA, Ryan PB, Rijnbeek PR. [Design and implementation of a standardized framework to generate and evaluate patient-level prediction models using observational healthcare data.](https://academic.oup.com/jamia/article/25/8/969/4989437) J Am Med Inform Assoc. 2018;25(8):969-975.
 
@@ -17,7 +17,7 @@ Features
 ========
 - Adds deep learning models to use in the OHDSI PatientLevelPrediction framework.
 - Allows to add custom deep learning models.
-- Includes an MLP, ResNet, Transformer, and core RealMLP
+- Includes MLP, ResNet, Transformer, and RealMLP models.
 - Allows to use all the features of [PatientLevelPrediction](https://github.com/OHDSI/PatientLevelPrediction/) to validate and explore your model performance.
 
 
@@ -27,14 +27,14 @@ DeepPatientLevelPrediction is an R package. It uses Python [PyTorch](https://pyt
 
 System Requirements
 ===================
-Requires R (version 4.0.0 or higher). Installation on Windows requires [RTools](http://cran.r-project.org/bin/windows/Rtools/). For training deep learning models in most cases an nvidia GPU is required using either Windows or Linux.
+Requires R (version 4.0.0 or higher). Installation on Windows requires [RTools](http://cran.r-project.org/bin/windows/Rtools/). A CPU can be used for small examples and tests; an NVIDIA GPU is recommended for larger deep learning model development.
 
 
 Getting Started
 ===============
 
 - To install the package please read the [Package installation guide](https://ohdsi.github.io/DeepPatientLevelPrediction/articles/Installing.html)
-- For Python, the recommended environment manager is `uv` with Python 3.12
+- Python dependencies are managed through `reticulate` when the package is loaded or used. Advanced users can point `RETICULATE_PYTHON` at a prebuilt environment for offline or controlled deployments.
 - Please read the main vignette for the package:
 [Building Deep Learning Models](https://ohdsi.github.io/DeepPatientLevelPrediction/articles/BuildingDeepModels.html)
 
@@ -51,8 +51,8 @@ Support
 
 Contributing
 ============
-Read [here](https://ohdsi.github.io/Hades/contribute.html) how you can contribute to this package. 
- 
+Read [here](https://ohdsi.github.io/Hades/contribute.html) how you can contribute to this package.
+
 License
 =======
 DeepPatientLevelPrediction is licensed under Apache License 2.0

--- a/vignettes/BuildingDeepModels.Rmd
+++ b/vignettes/BuildingDeepModels.Rmd
@@ -15,8 +15,8 @@ output:
   html_document:
     number_sections: yes
     toc: yes
-editor_options: 
-  markdown: 
+editor_options:
+  markdown:
     wrap: 72
 ---
 
@@ -37,7 +37,7 @@ knitr::opts_chunk$set(echo = TRUE)
 Patient level prediction aims to use historic data to learn a function
 between an input (a patient's features such as age/gender/comorbidities
 at index) and an output (whether the patient experienced an outcome
-during some time-at-risk). Deep learning is example of the the current
+during some time-at-risk). Deep learning is an example of the current
 state-of-the-art classifiers that can be implemented to learn the
 function between inputs and outputs.
 
@@ -63,7 +63,7 @@ methods.
 
 ## Background
 
-Deep Learning models are build by stacking an often large number of
+Deep Learning models are built by stacking an often large number of
 neural network layers that perform feature engineering steps, e.g
 embedding, and are collapsed in a final linear layer (equivalent to
 logistic regression). These algorithms need a lot of data to converge to
@@ -76,20 +76,20 @@ current implementation allows us to perform research at scale on the
 value and limitations of Deep Learning using observational healthcare
 data.
 
-In the package we use `pytorch` through the `reticulate` package.
+In the package we use PyTorch through the `reticulate` package.
 
 Many network architectures have recently been proposed and we have
 implemented a number of them, however, this list will grow in the near
 future. It is important to understand that some of these architectures
 require a 2D data matrix, i.e. \|patient\|x\|feature\|, and others use a
 3D data matrix \|patient\|x\|feature\|x\|time\|. The [FeatureExtraction
-Package](www.github.com\ohdsi\FeatureExtraction) has been extended to
+package](https://github.com/OHDSI/FeatureExtraction) has been extended to
 enable the extraction of both data formats as will be described with
 examples below.
 
 Note that training Deep Learning models is computationally intensive,
 our implementation therefore supports both GPU and CPU. A GPU
-is highly recommended and neccesary for most models for Deep Learning!
+is highly recommended for most deep learning model development.
 
 ## Requirements
 
@@ -105,7 +105,13 @@ settings that can be used within the `PatientLevelPrediction` package
 deep learning architecture you wish to fit (see below) and then you
 specify this as the modelSettings inside `runPlp()`.
 
+The model examples below assume you have already loaded both packages and
+created `plpData` and `populationSettings` as shown in the first-model
+vignette.
+
 ```{r, eval=FALSE}
+
+library(DeepPatientLevelPrediction)
 
 # load the data
 plpData <- PatientLevelPrediction::loadPlpData('locationOfData')
@@ -115,10 +121,12 @@ deepLearningModel <- DeepPatientLevelPrediction::setDefaultResNet()
 
 # use PatientLevelPrediction to fit model
 deepLearningResult <- PatientLevelPrediction::runPlp(
-    plpData = plpData, 
-    outcomeId = 1230, 
+    plpData = plpData,
+    outcomeId = 1230,
     modelSettings = deepLearningModel,
-    analysisId = 'resNetTorch', 
+    analysisId = 'resNetTorch',
+    populationSettings = populationSettings,
+    saveDirectory = file.path(getwd(), 'resNetTorch'),
     ...
   )
 
@@ -139,7 +147,7 @@ takes in the input feature values and feeds these forward through the
 graph to determine the output class. A process known as
 'backpropagation' is used to train the model. Backpropagation requires
 some ground truth and involves automatically calculating the derivative of
-the model parameters with respect to the the error between the model's
+the model parameters with respect to the error between the model's
 predictions and ground truth. Then the model learns how to adjust the
 model's parameters to reduce the error.
 
@@ -161,7 +169,7 @@ value of `0.2` means that 20% of the layers inputs will be set to
 0. This is used to reduce overfitting.
 
 The `sizeEmbedding` input specifies the size of the embedding used. The first
-layer is an embedding layer which converts each sparse feature to a dense learned 
+layer is an embedding layer which converts each sparse feature to a dense learned
 vector. An embedding is a lower dimensional projection of the features
 where distance between points is a measure of similarity.
 
@@ -185,22 +193,22 @@ fast.
 The `seed` lets the user use the same random initialization of the network's
 weights as a previous run.
 
-The `hyperParamSearch` chooses the strategy to find the best hyperparameters. 
+The `hyperParamSearch` chooses the strategy to find the best hyperparameters.
 Currently a random search and grid search are supported. Grid search searches
-every possible combination of hyperparameters while random search samples 
+every possible combination of hyperparameters while random search samples
 randomly from the combinations. Since neural networks can be very flexible and
 have many hyperparameter combinations it's almost never feasible to do a full
 grid search unless the network is really small.
 
 The `randomSample` chooses how many random samples to use.
 
-The `device` specifies what device to use. Either `cpu` or `cuda`. Or if you 
-have many GPU's `cuda:x` where x is the gpu number as seen in `nvidia-smi`.
+The `device` specifies what device to use. Either `cpu` or `cuda`. If you
+have multiple GPUs, use `cuda:x`, where `x` is the GPU number as seen in `nvidia-smi`.
 
 The `batchSize` corresponds to the number of data points (patients)
 used per iteration to estimate the network error during model fitting.
 
-The `epochs` corresponds to how many time to run through the entire
+The `epochs` corresponds to how many times to run through the entire
 training data while fitting the model.
 
 
@@ -208,10 +216,10 @@ training data while fitting the model.
 #### Example Code
 
 For example, the following code will try 10 different network
-configurations sampled from the possible combinations given and pick the one 
-that obtains the greatest AUROC via cross validation in the training data and 
-then fit the model with that configuration using all the training data. The 
-standard output of `runPlp()` will be returned - this contains the MLP model 
+configurations sampled from the possible combinations given and pick the one
+that obtains the greatest AUROC via cross validation in the training data and
+then fit the model with that configuration using all the training data. The
+standard output of `runPlp()` will be returned - this contains the MLP model
 along with the performance details and settings. Note that all possible
 combinations are 2*2*2*2 or 16 but specify ```randomSample=10``` to only try
 10 of those.
@@ -220,7 +228,7 @@ combinations are 2*2*2*2 or 16 but specify ```randomSample=10``` to only try
 
 modelSettings <- setMultiLayerPerceptron(
   numLayers = c(3L, 5L),
-  sizeHidden = c(64L, 128L), 
+  sizeHidden = c(64L, 128L),
   dropout = c(0.2),
   sizeEmbedding = c(32L, 64L),
   estimatorSettings = setEstimator(
@@ -234,23 +242,23 @@ modelSettings <- setMultiLayerPerceptron(
 )
 
 mlpResult <- PatientLevelPrediction::runPlp(
-    plpData = plpData, 
-    outcomeId = 3, 
+    plpData = plpData,
+    outcomeId = 3,
     modelSettings = modelSettings,
-    analysisId = 'MLP', 
-    analysisName = 'Testing Deep Learning', 
-    populationSettings = populationSet, 
-    splitSettings = PatientLevelPrediction::createDefaultSplitSetting(), 
-    preprocessSettings = PatientLevelPrediction::createPreprocessSettings(), 
+    analysisId = 'MLP',
+    analysisName = 'Testing Deep Learning',
+    populationSettings = populationSettings,
+    splitSettings = PatientLevelPrediction::createDefaultSplitSetting(),
+    preprocessSettings = PatientLevelPrediction::createPreprocessSettings(),
     executeSettings = PatientLevelPrediction::createExecuteSettings(
-      runSplitData = TRUE, 
-      runSampleData = FALSE, 
-      runFeatureEngineering = FALSE, 
-      runPreprocessData = TRUE, 
-      runModelDevelopment = TRUE, 
+      runSplitData = TRUE,
+      runSampleData = FALSE,
+      runFeatureEngineering = FALSE,
+      runPreprocessData = TRUE,
+      runModelDevelopment = TRUE,
       runCovariateSummary = FALSE
-    ), 
-    saveDirectory = file.path(testLoc, 'DeepNNTorch')
+    ),
+    saveDirectory = file.path(getwd(), 'MLP')
   )
 
 ```
@@ -330,24 +338,24 @@ random samples to use
 For example, the following code will fit a two layer ResNet where each
 layer has 32 neurons which increases by a factor of two before
 decreasing again (hiddenFactor). 10% of inputs to each layer and
-residual connection within the layer are randomly zeroed during training but 
-not testing.The embedding layer has 32 neurons. Learning rate of 3e-4 with 
+residual connection within the layer are randomly zeroed during training but
+not testing. The embedding layer has 32 neurons. Learning rate of 3e-4 with
 weight decay of 1e-6 is used for the optimizer. No hyperparameter search is done
 since each input only includes one option.
 
 ```{r, eval=FALSE}
 
 resset <- setResNet(
-  numLayers = c(2L), 
+  numLayers = c(2L),
   sizeHidden = c(32L),
   hiddenFactor = c(2L),
-  residualDropout = c(0.1), 
+  residualDropout = c(0.1),
   hiddenDropout = c(0.1),
   sizeEmbedding = c(32L),
   estimatorSettings = setEstimator(learningRate = c(3e-4),
                                    weightDecay = c(1e-6),
                                    #device='cuda:0', # uncomment to use GPU
-                                   batchSize = 128L, 
+                                   batchSize = 128L,
                                    epochs = 3L,
                                    seed = 42L),
   hyperParamSearch = 'random',
@@ -355,25 +363,72 @@ resset <- setResNet(
 )
 
 resResult <- PatientLevelPrediction::runPlp(
-    plpData = plpData, 
-    outcomeId = 3, 
+    plpData = plpData,
+    outcomeId = 3,
     modelSettings = resset,
-    analysisId = 'ResNet', 
-    analysisName = 'Testing ResNet', 
-    populationSettings = populationSet, 
-    splitSettings = PatientLevelPrediction::createDefaultSplitSetting(), 
-    preprocessSettings = PatientLevelPrediction::createPreprocessSettings(), 
+    analysisId = 'ResNet',
+    analysisName = 'Testing ResNet',
+    populationSettings = populationSettings,
+    splitSettings = PatientLevelPrediction::createDefaultSplitSetting(),
+    preprocessSettings = PatientLevelPrediction::createPreprocessSettings(),
     executeSettings = PatientLevelPrediction::createExecuteSettings(
-      runSplitData = TRUE, 
-      runSampleData = FALSE, 
-      runFeatureEngineering = FALSE, 
-      runPreprocessData = TRUE, 
-      runModelDevelopment = TRUE, 
+      runSplitData = TRUE,
+      runSampleData = FALSE,
+      runFeatureEngineering = FALSE,
+      runPreprocessData = TRUE,
+      runModelDevelopment = TRUE,
       runCovariateSummary = FALSE
-    ), 
+    ),
     saveDirectory = file.path(getwd(), 'ResNet') # change to save elsewhere
   )
 
+```
+
+## RealMLP
+
+### Overall concept
+
+RealMLP is a tabular neural network with paper-aligned defaults for
+optimizer settings, schedules, feature scaling, and data-dependent
+initialization. It is exposed through `setRealMLP()` and can be used as
+the `modelSettings` argument in `PatientLevelPrediction::runPlp()`.
+
+Like the other model setting helpers, `setRealMLP()` can be called with
+one value per argument for a fixed model configuration, or with multiple
+values for tunable parameters such as `numLayers`, `sizeHidden`,
+`dropout`, and `sizeEmbedding` to run a hyperparameter or sensitivity
+search.
+
+### Example Code
+
+```{r, eval=FALSE}
+
+modelSettings <- setRealMLP(
+  numLayers = 3L,
+  sizeHidden = 256L,
+  dropout = 0.15,
+  device = "cpu"
+)
+
+realMlpResult <- PatientLevelPrediction::runPlp(
+    plpData = plpData,
+    outcomeId = 3,
+    modelSettings = modelSettings,
+    analysisId = 'RealMLP',
+    analysisName = 'Testing RealMLP',
+    populationSettings = populationSettings,
+    splitSettings = PatientLevelPrediction::createDefaultSplitSetting(),
+    preprocessSettings = PatientLevelPrediction::createPreprocessSettings(),
+    executeSettings = PatientLevelPrediction::createExecuteSettings(
+      runSplitData = TRUE,
+      runSampleData = FALSE,
+      runFeatureEngineering = FALSE,
+      runPreprocessData = TRUE,
+      runModelDevelopment = TRUE,
+      runCovariateSummary = FALSE
+    ),
+    saveDirectory = file.path(getwd(), 'RealMLP') # change to save elsewhere
+  )
 ```
 
 ## Transformer
@@ -432,7 +487,7 @@ block
 
 modelSettings <- setTransformer(numBlocks = 3L,
                                 dimToken = 32L,
-                                dimOut = 1, 
+                                dimOut = 1,
                                 numHeads = 4L,
                                 attDropout = 0.25,
                                 ffnDropout = 0.25,
@@ -445,26 +500,26 @@ modelSettings <- setTransformer(numBlocks = 3L,
                                   device = 'cpu'
                                 ),
                                 randomSample=1L)
-                              
+
 
 
 TransformerResult <- PatientLevelPrediction::runPlp(
-    plpData = plpData, 
-    outcomeId = 3, 
+    plpData = plpData,
+    outcomeId = 3,
     modelSettings = modelSettings,
-    analysisId = 'Transformer', 
-    analysisName = 'Testing transformer', 
-    populationSettings = populationSet, 
-    splitSettings = PatientLevelPrediction::createDefaultSplitSetting(), 
-    preprocessSettings = PatientLevelPrediction::createPreprocessSettings(), 
+    analysisId = 'Transformer',
+    analysisName = 'Testing transformer',
+    populationSettings = populationSettings,
+    splitSettings = PatientLevelPrediction::createDefaultSplitSetting(),
+    preprocessSettings = PatientLevelPrediction::createPreprocessSettings(),
     executeSettings = PatientLevelPrediction::createExecuteSettings(
-      runSplitData = TRUE, 
-      runSampleData = FALSE, 
-      runFeatureEngineering = FALSE, 
-      runPreprocessData = TRUE, 
-      runModelDevelopment = TRUE, 
+      runSplitData = TRUE,
+      runSampleData = FALSE,
+      runFeatureEngineering = FALSE,
+      runPreprocessData = TRUE,
+      runModelDevelopment = TRUE,
       runCovariateSummary = FALSE
-    ), 
+    ),
     saveDirectory = file.path(getwd(), 'Transformer') # change to save elsewhere
   )
 ```

--- a/vignettes/FirstModel.Rmd
+++ b/vignettes/FirstModel.Rmd
@@ -72,15 +72,15 @@ Next we need to define our database details, which defines from which database w
 
 ```{r, echo = TRUE, message = FALSE, warning = FALSE,tidy=FALSE,eval=FALSE}
 databaseDetails <- PatientLevelPrediction::createDatabaseDetails(
-  connectionDetails = connectionDetails, 
+  connectionDetails = connectionDetails,
   cdmDatabaseSchema = "main",
   cdmDatabaseId = "1",
-  cohortDatabaseSchema = "main", 
-  cohortTable = "cohort", 
-  targetId= 4, 
+  cohortDatabaseSchema = "main",
+  cohortTable = "cohort",
+  targetId= 4,
   outcomeIds = 3,
-  outcomeDatabaseSchema = "main", 
-  outcomeTable =  "cohort", 
+  outcomeDatabaseSchema = "main",
+  outcomeTable =  "cohort",
   cdmDatabaseName = 'eunomia'
 )
 ```
@@ -91,8 +91,8 @@ Now we define our study population and get the plpData object from the database.
 
 ```{r, echo = TRUE, message = FALSE, warning = FALSE,tidy=FALSE,eval=FALSE}
 populationSettings <- PatientLevelPrediction::createStudyPopulationSettings(
-                                                          requireTimeAtRisk = F, 
-                                                          riskWindowStart = 1, 
+                                                          requireTimeAtRisk = FALSE,
+                                                          riskWindowStart = 1,
                                                           riskWindowEnd = 365)
 plpData <- PatientLevelPrediction::getPlpData(
   databaseDetails = databaseDetails,
@@ -100,13 +100,13 @@ plpData <- PatientLevelPrediction::getPlpData(
   restrictPlpDataSettings = PatientLevelPrediction::createRestrictPlpDataSettings())
 ```
 
-When defining our study population we define the time-at-risk. Which is when we are predicing if a certain patient gets the outcome or not. Here we predict the outcome from the day after the patient starts using NSAIDs until one year later.
+When defining our study population we define the time-at-risk. Which is when we are predicting if a certain patient gets the outcome or not. Here we predict the outcome from the day after the patient starts using NSAIDs until one year later.
 
 ## The model
 
 Now it's time to define our deep learning model. It can be daunting for those not familiar with deep learning to define their first model since the models are very flexible and have many hyperparameters to define for your model architecture. To help with this `deepPLP` has helper functions with a sensible set of hyperparameters for testing. Best practice is though to do an extensive hyperparameter tuning step using cross validation.
 
-We will use a simple ResNet for our example. ResNet are simple models that have skip connections between layers that allow for deeper models without overfitting. The default ResNet is a 6 layer model with 512 neurons per layer.
+We will use a simple ResNet for our example. ResNets use skip connections between layers to support deeper models without overfitting as quickly. The default ResNet is a 6 layer model with 512 neurons per layer.
 
 ```{r, echo = TRUE, message = FALSE, warning = FALSE,tidy=FALSE,eval=FALSE}
 library(DeepPatientLevelPrediction)
@@ -129,13 +129,12 @@ Now all that is left is using the PLP to train our first deep learning model. If
 
 ```{r, echo = TRUE, message = FALSE, warning = FALSE,tidy=FALSE,eval=FALSE}
 plpResults <- PatientLevelPrediction::runPlp(plpData = plpData,
-               outcomeId = 3,
-               modelSettings = modelSettings,
-               analysisId = 'ResNet',
-               analysisName = 'Testing DeepPlp',
-               populationSettings = populationSettings,
-               saveDirectory = "ResNet"
-                                                      )
+                                             outcomeId = 3,
+                                             modelSettings = modelSettings,
+                                             analysisId = "ResNet",
+                                             analysisName = "Testing DeepPLP",
+                                             populationSettings = populationSettings,
+                                             saveDirectory = "ResNet")
 ```
 
 On my computer this takes about 20 seconds per epoch. While you probably won't see any kind of good performance using this model and this data, at least the training loss should be decreasing in the printed output.

--- a/vignettes/Installing.Rmd
+++ b/vignettes/Installing.Rmd
@@ -39,7 +39,7 @@ Under Windows the OHDSI Deep Patient Level Prediction (DeepPLP) package requires
 
 -   R (<https://cran.r-project.org/> ) - (R \>= 4.0.0, but latest is recommended)
 -   Python - Recommend Python 3.12. Python \>= 3.10 is supported
--   Rstudio (<https://www.rstudio.com/> )
+-   RStudio (<https://www.rstudio.com/> )
 -   Java (<http://www.java.com> )
 -   RTools (<https://cran.r-project.org/bin/windows/Rtools/>)
 
@@ -49,7 +49,7 @@ Under Mac and Linux the OHDSI DeepPLP package requires installing:
 
 -   R (<https://cran.r-project.org/> ) - (R \>= 4.0.0, but latest is recommended)
 -   Python - Recommend Python 3.12. Python \>= 3.10 is supported
--   Rstudio (<https://www.rstudio.com/> )
+-   RStudio (<https://www.rstudio.com/> )
 -   Java (<http://www.java.com> )
 -   Xcode command line tools(run in terminal: xcode-select --install) [MAC USERS ONLY]
 
@@ -61,22 +61,29 @@ If you do not want the official release you could install the bleeding edge vers
 
 Note that the latest develop branch could contain bugs, please report them to us if you experience problems.
 
-## Installing Python environment
+## Python environment
 
-Since the package uses `pytorch` through `reticulate`, a working Python installation is required. We recommend using `uv` with Python 3.12.
+Since the package uses PyTorch through `reticulate`, a working Python environment is required. For most users on a computer with internet access, no manual Python setup is needed: loading or using `DeepPatientLevelPrediction` should let `reticulate` create a managed environment from the package requirements.
 
-Install `uv` by following the official instructions:
+You can verify the active interpreter with:
 
-<https://docs.astral.sh/uv/getting-started/installation/>
+```{r, echo = TRUE, message = FALSE, warning = FALSE,tidy=FALSE,eval=FALSE}
+library(DeepPatientLevelPrediction)
+reticulate::py_config()
+```
 
-Then create a local virtual environment for this project:
+Advanced users, users with strict reproducibility requirements, or users in airgapped environments can manage the Python environment themselves and tell `reticulate` which interpreter to use. One option is to create the environment with `uv` and Python 3.12:
 
 ```bash
 uv python install 3.12
 uv venv --python 3.12
+uv pip install polars tqdm pyarrow duckdb nvidia-ml-py numpy
+uv pip install "torch==2.10.0" --index https://download.pytorch.org/whl/cpu/
 ```
 
-Tell `reticulate` to use that interpreter by setting `RETICULATE_PYTHON` in `.Renviron`.
+The second `uv pip install` command installs the CPU build of PyTorch. If you want to train on a GPU, install the PyTorch build that matches your CUDA setup instead.
+
+To force `reticulate` to use a manually managed interpreter, set `RETICULATE_PYTHON` in `.Renviron`.
 
 For Linux/macOS:
 
@@ -90,11 +97,7 @@ For Windows:
 RETICULATE_PYTHON="C:/path/to/project/.venv/Scripts/python.exe"
 ```
 
-Then restart your R session. You can verify the active interpreter with:
-
-```{r, echo = TRUE, message = FALSE, warning = FALSE,tidy=FALSE,eval=FALSE}
-reticulate::py_config()
-```
+Then restart your R session.
 
 Python 3.9 is end-of-life and should not be used. Python 3.10 is still supported, but Python 3.12 is recommended.
 
@@ -107,69 +110,48 @@ install.packages("remotes")
 remotes::install_github("OHDSI/DeepPatientLevelPrediction")
 ```
 
-This should install the required python packages. If that doesn't happen it can be triggered by calling:
+Loading the package or using the `torch` helper should trigger `reticulate` to resolve the Python requirements if you have not configured `RETICULATE_PYTHON`.
 
-```
+```{r, echo = TRUE, message = FALSE, warning = FALSE, tidy=FALSE, eval=FALSE}
 library(DeepPatientLevelPrediction)
 torch$randn(10L)
 ```
 
-This should print out a tensor with ten different values. 
+This should print out a tensor with ten different values.
 
-When installing make sure to close any other Rstudio sessions that are using `DeepPatientLevelPrediction` or any dependency. Keeping Rstudio sessions open can cause locks on windows that prevent the package installing.
+When installing make sure to close any other RStudio sessions that are using `DeepPatientLevelPrediction` or any dependency. Keeping RStudio sessions open can cause locks on Windows that prevent the package installing.
 
 # Testing Installation
 
 ```{r, echo = TRUE, message = FALSE, warning = FALSE,tidy=FALSE,eval=FALSE}
-library(PatientLevelPrediction)
 library(DeepPatientLevelPrediction)
 
-data(plpDataSimulationProfile)
-sampleSize <- 1e3
-plpData <- simulatePlpData(
-  plpDataSimulationProfile,
-  n = sampleSize 
+torch$randn(10L)
+
+modelSettings <- setResNet(
+  numLayers = 2L,
+  sizeHidden = 64L,
+  hiddenFactor = 1L,
+  residualDropout = 0,
+  hiddenDropout = 0.2,
+  sizeEmbedding = 64L,
+  estimatorSettings = setEstimator(
+    learningRate = 3e-4,
+    weightDecay = 1e-6,
+    device = "cpu",
+    batchSize = 128L,
+    epochs = 3L,
+    seed = 42L
+  ),
+  hyperParamSearch = "random",
+  randomSample = 1L
 )
 
-populationSettings <- PatientLevelPrediction::createStudyPopulationSettings(
-                                                          requireTimeAtRisk = F, 
-                                                          riskWindowStart = 1, 
-                                                          riskWindowEnd = 365)
-# a very simple resnet
-modelSettings <- setResNet(numLayers = 2L, 
-                           sizeHidden = 64L, 
-                           hiddenFactor = 1L,
-                           residualDropout = 0, 
-                           hiddenDropout = 0.2, 
-                           sizeEmbedding = 64L, 
-                           estimatorSettings = setEstimator(learningRate = 3e-4,
-                                                            weightDecay = 1e-6,
-                                                            device='cpu',
-                                                            batchSize=128L,
-                                                            epochs=3L,
-                                                            seed = 42),
-                           hyperParamSearch = 'random',
-                           randomSample = 1L)
-
-plpResults <- PatientLevelPrediction::runPlp(plpData = plpData,
-               outcomeId = 3,
-               modelSettings = modelSettings,
-               analysisId = 'Test',
-               analysisName = 'Testing DeepPlp',
-               populationSettings = populationSettings,
-               splitSettings = createDefaultSplitSetting(),
-               sampleSettings = createSampleSettings(), 
-               featureEngineeringSettings = createFeatureEngineeringSettings(), 
-               preprocessSettings = createPreprocessSettings(),
-               logSettings = createLogSettings(),
-               executeSettings = createExecuteSettings(runSplitData = TRUE,
-                                                      runSampleData = FALSE,
-                                                      runFeatureEngineering = FALSE,
-                                                      runPreprocessData = TRUE,
-                                                      runModelDevelopment = TRUE,
-                                                      runCovariateSummary = TRUE
-                                                      ))
+stopifnot(inherits(modelSettings, "modelSettings"))
 ```
+
+To run an end-to-end patient-level prediction example, continue with the
+[first-model vignette](FirstModel.html).
 
 # Acknowledgments
 


### PR DESCRIPTION
## Summary
- clarify Python environment setup so regular users rely on reticulate-managed dependencies, with manual `RETICULATE_PYTHON` setup documented for advanced/offline deployments
- update README and vignette examples to match current `runPlp()` requirements and naming
- add RealMLP coverage to the model-building vignette and document intended vector-parameter search behavior
- clean stale prose and broken example variables/output paths

## Testing
- rendered all vignettes with `rmarkdown::render()`
- parsed all vignette chunks with `knitr::purl()` + `parse()`
- ran constructor snippets for ResNet, MLP, Transformer, and RealMLP
- ran the install smoke snippet
- ran the full first-model Eunomia `runPlp()` workflow successfully
- `git diff --check`