### PR TITLE
Fix RealMLP grid search parameter expansion

### DIFF
--- a/R/RealMLP.R
+++ b/R/RealMLP.R
@@ -28,6 +28,11 @@
 #' @param tokenAggregation token aggregation mode: "auto", "mean", "sum", "sum_len_norm"
 #' @param featureScaleMode feature scale mode: "auto", "scalar", "vector"
 #' @param device     "cpu" or "cuda" (default "cpu")
+#' @param hyperParamSearch Which kind of hyperparameter search to use: random
+#' sampling or exhaustive grid search. Default: "grid"
+#' @param randomSample How many random samples from hyperparameter space to use
+#' when `hyperParamSearch = "random"`
+#' @param randomSampleSeed Random seed to sample hyperparameter combinations
 #' @export
 setRealMLP <- function(
   numLayers = 3L,
@@ -52,7 +57,10 @@ setRealMLP <- function(
   paperMode = TRUE,
   tokenAggregation = "auto",
   featureScaleMode = "auto",
-  device = "cpu"
+  device = "cpu",
+  hyperParamSearch = "grid",
+  randomSample = 100,
+  randomSampleSeed = NULL
 ) {
   checkIsClass(numLayers, c("integer", "numeric"))
   checkHigherEqual(numLayers, 1)
@@ -64,14 +72,13 @@ setRealMLP <- function(
   checkHigherEqual(sizeEmbedding, 1)
   checkIsClass(labelSmoothing, "numeric")
   checkHigherEqual(labelSmoothing, 0)
-  if (labelSmoothing > 1) {
+  if (any(labelSmoothing > 1)) {
     stop("labelSmoothing needs to be <= 1")
   }
   checkIsClass(numericEmbeddingMode, "character")
-  checkInStringVector(
-    numericEmbeddingMode,
-    c("scale", "pl", "pbld")
-  )
+  if (!all(numericEmbeddingMode %in% c("scale", "pl", "pbld"))) {
+    stop("numericEmbeddingMode has incorrect value")
+  }
   checkIsClass(numericNumFrequencies, c("integer", "numeric"))
   checkHigherEqual(numericNumFrequencies, 1)
   checkIsClass(numericPeriodicInitStd, "numeric")
@@ -81,10 +88,9 @@ setRealMLP <- function(
   checkIsClass(numericPbldEmbeddingDim, c("integer", "numeric"))
   checkHigherEqual(numericPbldEmbeddingDim, 1)
   checkIsClass(dataDependentInitMode, "character")
-  checkInStringVector(
-    dataDependentInitMode,
-    c("paper_lsuv", "current")
-  )
+  if (!all(dataDependentInitMode %in% c("paper_lsuv", "current"))) {
+    stop("dataDependentInitMode has incorrect value")
+  }
   checkIsClass(dataDependentInitTargetVar, "numeric")
   checkHigher(dataDependentInitTargetVar, 0)
   checkIsClass(dataDependentInitMaxRows, c("integer", "numeric"))
@@ -103,23 +109,21 @@ setRealMLP <- function(
   checkHigherEqual(embeddingLrMult, 0)
   checkIsClass(paperMode, "logical")
   checkIsClass(tokenAggregation, "character")
-  checkInStringVector(
-    tokenAggregation,
-    c("auto", "mean", "sum", "sum_len_norm")
-  )
+  if (!all(tokenAggregation %in% c("auto", "mean", "sum", "sum_len_norm"))) {
+    stop("tokenAggregation has incorrect value")
+  }
   checkIsClass(featureScaleMode, "character")
-  checkInStringVector(
-    featureScaleMode,
-    c("auto", "scalar", "vector")
-  )
+  if (!all(featureScaleMode %in% c("auto", "scalar", "vector"))) {
+    stop("featureScaleMode has incorrect value")
+  }
   checkIsClass(device, c("character", "function"))
 
-  if (tokenAggregation == "auto") {
-    tokenAggregation <- if (isTRUE(paperMode)) "sum" else "mean"
-  }
-  if (featureScaleMode == "auto") {
-    featureScaleMode <- "scalar"
-  }
+  checkIsClass(hyperParamSearch, "character")
+
+  checkIsClass(randomSample, c("numeric", "integer"))
+  checkHigherEqual(randomSample, 1)
+
+  checkIsClass(randomSampleSeed, c("numeric", "integer", "NULL"))
 
   est <- setEstimator(
     learningRate = 2e-3,
@@ -161,8 +165,9 @@ setRealMLP <- function(
   est$dataDependentInitBiasMode <- "he5"
   est$dataDependentInitBiasScale <- 1.0
   est$dataDependentInitBiasRefitSteps <- as.integer(dataDependentInitBiasRefitSteps)
+  est$paramsToTune <- extractParamsToTune(est)
 
-  param <- list(
+  paramGrid <- list(
     numLayers = as.integer(numLayers),
     sizeHidden = as.integer(sizeHidden),
     dropout = dropout,
@@ -176,13 +181,49 @@ setRealMLP <- function(
     tokenAggregation = tokenAggregation,
     featureScaleMode = featureScaleMode
   )
+  paramGrid <- c(paramGrid, est$paramsToTune)
+
+  param <- PatientLevelPrediction::listCartesian(paramGrid)
+  param <- lapply(param, function(x) {
+    if (x$tokenAggregation == "auto") {
+      x$tokenAggregation <- if (isTRUE(x$paperMode)) "sum" else "mean"
+    }
+    if (x$featureScaleMode == "auto") {
+      x$featureScaleMode <- "scalar"
+    }
+    x
+  })
+
+  if (hyperParamSearch == "random" && randomSample > length(param)) {
+    stop(paste(
+      "\n Chosen amount of randomSamples is higher than the amount of
+               possible hyperparameter combinations.", "\n randomSample:",
+      randomSample, "\n Possible hyperparameter combinations:",
+      length(param), "\n Please lower the amount of randomSamples"
+    ))
+  }
+
+  if (hyperParamSearch == "random") {
+    suppressWarnings(withr::with_seed(randomSampleSeed, {
+      param <- param[sample(
+        length(param),
+        randomSample
+      )]
+    }))
+  }
 
   results <- list(
     fitFunction = "DeepPatientLevelPrediction::fitEstimator",
-    param = list(param), # fixed tuned defaults; no grid/HPO
+    param = param,
     estimatorSettings = est,
     saveType = "file",
-    modelParamNames = c("numLayers", "sizeHidden", "dropout", "sizeEmbedding"),
+    modelParamNames = c(
+      "numLayers", "sizeHidden", "dropout", "sizeEmbedding",
+      "numericEmbeddingMode", "numericNumFrequencies",
+      "numericPeriodicInitStd", "numericPbldHiddenDim",
+      "numericPbldEmbeddingDim", "paperMode", "tokenAggregation",
+      "featureScaleMode"
+    ),
     modelType = "RealMLP"
   )
   attr(results$param, "settings")$modelType <- results$modelType

--- a/man/setRealMLP.Rd
+++ b/man/setRealMLP.Rd
@@ -27,7 +27,10 @@ setRealMLP(
   paperMode = TRUE,
   tokenAggregation = "auto",
   featureScaleMode = "auto",
-  device = "cpu"
+  device = "cpu",
+  hyperParamSearch = "grid",
+  randomSample = 100,
+  randomSampleSeed = NULL
 )
 }
 \arguments{
@@ -76,6 +79,14 @@ setRealMLP(
 \item{featureScaleMode}{feature scale mode: "auto", "scalar", "vector"}
 
 \item{device}{"cpu" or "cuda" (default "cpu")}
+
+\item{hyperParamSearch}{Which kind of hyperparameter search to use: random
+sampling or exhaustive grid search. Default: "grid"}
+
+\item{randomSample}{How many random samples from hyperparameter space to use
+when `hyperParamSearch = "random"`}
+
+\item{randomSampleSeed}{Random seed to sample hyperparameter combinations}
 }
 \description{
 Create settings for the RealMLP model (binary classification).

--- a/tests/testthat/test-RealMLP.R
+++ b/tests/testthat/test-RealMLP.R
@@ -106,6 +106,29 @@ test_that("setRealMLP random search samples expanded grid combinations", {
   )
 })
 
+test_that("setRealMLP validates vector-aware RealMLP parameters", {
+  expect_error(
+    setRealMLP(labelSmoothing = 1.1),
+    "labelSmoothing needs to be <= 1"
+  )
+  expect_error(
+    setRealMLP(numericEmbeddingMode = c("scale", "invalid")),
+    "numericEmbeddingMode has incorrect value"
+  )
+  expect_error(
+    setRealMLP(dataDependentInitMode = c("paper_lsuv", "invalid")),
+    "dataDependentInitMode has incorrect value"
+  )
+  expect_error(
+    setRealMLP(tokenAggregation = c("mean", "invalid")),
+    "tokenAggregation has incorrect value"
+  )
+  expect_error(
+    setRealMLP(featureScaleMode = c("scalar", "invalid")),
+    "featureScaleMode has incorrect value"
+  )
+})
+
 test_that("RealMLP supports PL and PBLD numerical embedding modes", {
   realMlp <- reticulate::import_from_path("RealMLP", path = path)$RealMLP
   featureInfo <- dataset$get_feature_info()

--- a/tests/testthat/test-RealMLP.R
+++ b/tests/testthat/test-RealMLP.R
@@ -45,6 +45,67 @@ test_that("setRealMLP settings are created correctly", {
   expect_equal(settings$param[[1]]$featureScaleMode, "scalar")
 })
 
+test_that("setRealMLP expands vector parameters into grid combinations", {
+  settings <- setRealMLP(
+    numLayers = c(1L, 2L),
+    sizeHidden = c(16L, 32L),
+    dropout = c(0.1, 0.2),
+    sizeEmbedding = 8L,
+    labelSmoothing = c(0, 0.1),
+    numericEmbeddingMode = c("scale", "pbld"),
+    paperMode = c(TRUE, FALSE),
+    tokenAggregation = "auto",
+    featureScaleMode = "auto"
+  )
+
+  expect_equal(length(settings$param), 64L)
+  expect_true(all(vapply(settings$param, function(x) length(x$numLayers), integer(1)) == 1L))
+  expect_true(all(vapply(settings$param, function(x) length(x$sizeHidden), integer(1)) == 1L))
+  expect_true(all(vapply(settings$param, function(x) length(x$dropout), integer(1)) == 1L))
+  expect_true(all(vapply(settings$param, function(x) length(x$numericEmbeddingMode), integer(1)) == 1L))
+  expect_true(all(vapply(settings$param, function(x) length(x$estimator.labelSmoothing), integer(1)) == 1L))
+  expect_setequal(
+    vapply(settings$param, function(x) x$estimator.labelSmoothing, numeric(1)),
+    c(0, 0.1)
+  )
+  expect_false(any(vapply(settings$param, function(x) x$tokenAggregation == "auto", logical(1))))
+  expect_false(any(vapply(settings$param, function(x) x$featureScaleMode == "auto", logical(1))))
+  expect_true(all(
+    vapply(settings$param, function(x) {
+      if (isTRUE(x$paperMode)) {
+        x$tokenAggregation == "sum"
+      } else {
+        x$tokenAggregation == "mean"
+      }
+    }, logical(1))
+  ))
+  expect_true(all(vapply(settings$param, function(x) x$featureScaleMode == "scalar", logical(1))))
+})
+
+test_that("setRealMLP random search samples expanded grid combinations", {
+  settings <- setRealMLP(
+    numLayers = c(1L, 2L),
+    sizeHidden = c(16L, 32L),
+    dropout = c(0.1, 0.2),
+    sizeEmbedding = 8L,
+    hyperParamSearch = "random",
+    randomSample = 3L,
+    randomSampleSeed = 42L
+  )
+
+  expect_equal(length(settings$param), 3L)
+  expect_error(
+    setRealMLP(
+      numLayers = 1L,
+      sizeHidden = 16L,
+      dropout = 0.1,
+      sizeEmbedding = 8L,
+      hyperParamSearch = "random",
+      randomSample = 2L
+    )
+  )
+})
+
 test_that("RealMLP supports PL and PBLD numerical embedding modes", {
   realMlp <- reticulate::import_from_path("RealMLP", path = path)$RealMLP
   featureInfo <- dataset$get_feature_info()


### PR DESCRIPTION
## Summary
- expand vector-valued RealMLP model parameters into grid combinations
- support random sampling of the expanded RealMLP parameter grid
- include RealMLP-specific estimator knobs in the tuning grid after they are added to estimator settings
- add focused tests for grid expansion and random search behavior

Closes #176

## Testing
- `git diff --check`
- `RETICULATE_PYTHON=/home/egill/github/DeepPatientLevelPrediction/docs-current-code-snippets/.venv/bin/python RETICULATE_USE_MANAGED_VENV=no Rscript -e 'pkgload::load_all(); testthat::test_file("tests/testthat/test-RealMLP.R")'`