### PR TITLE
fix: pin dataloader memory only for cuda

### DIFF
--- a/.github/workflows/R_CDM_check_hades.yaml
+++ b/.github/workflows/R_CDM_check_hades.yaml
@@ -93,6 +93,8 @@ jobs:
           else
             uv pip install "torch==${{ matrix.config.torch }}" --index https://download.pytorch.org/whl/cpu/
           fi
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
 
       - uses: r-lib/actions/check-r-package@v2
         with:

--- a/inst/python/Estimator.py
+++ b/inst/python/Estimator.py
@@ -7,10 +7,10 @@ import random
 
 import torch
 from torch.utils.data import DataLoader, BatchSampler, RandomSampler, SequentialSampler
-from tqdm import tqdm
 
 from gpu_memory_cleanup import memory_cleanup
 from InitStrategy import InitStrategy, DefaultInitStrategy
+from progress import tqdm
 from schedules import get_schedule
 try:
     import numpy as np

--- a/inst/python/Estimator.py
+++ b/inst/python/Estimator.py
@@ -1,3 +1,4 @@
+import gc
 import time
 import pathlib
 import inspect
@@ -539,6 +540,8 @@ class Estimator:
             f"Average time per epoch was: {torch.mean(torch.as_tensor(times)).item()} seconds"
         )
         self.finish_fit(all_scores, model_state_dict, trained_epochs, learning_rates)
+        del train_dataloader, test_dataloader
+        gc.collect()
         return
 
     def fit_epoch(self, dataloader):
@@ -721,6 +724,8 @@ class Estimator:
             for group in self.optimizer.param_groups:
                 group["lr"] = learning_rates[epoch] * group.get("lr_factor", 1.0)
             self.fit_epoch(dataloader)
+        del dataloader
+        gc.collect()
         return
 
     def save(self, path, name):
@@ -758,6 +763,8 @@ class Estimator:
                     pred = self.model(sub_batch[0])
                     predictions.append(self._prediction_proba(pred))
             predictions = torch.concat(predictions).cpu().numpy()
+        del dataloader
+        gc.collect()
         return predictions
 
     def predict(self, dataset, threshold=None):

--- a/inst/python/Estimator.py
+++ b/inst/python/Estimator.py
@@ -31,6 +31,7 @@ class Estimator:
             self.device = parameters["estimator_settings"]["device"]()
         else:
             self.device = parameters["estimator_settings"]["device"]
+        self.pin_memory = self._should_pin_memory(self.device)
         torch.manual_seed(seed=self.seed)
         random.seed(self.seed)
         if np is not None:
@@ -236,6 +237,10 @@ class Estimator:
         torch_compile = parameters["estimator_settings"].get("compile", False)
         if torch_compile:
             self.model = torch.compile(self.model, dynamic=False)
+
+    @staticmethod
+    def _should_pin_memory(device):
+        return str(device).lower().startswith("cuda")
 
     def _configure_determinism(self):
         if not self.deterministic:
@@ -473,7 +478,7 @@ class Estimator:
             ),
             num_workers=self.num_workers,
             persistent_workers=self.persistent_workers,
-            pin_memory=True,
+            pin_memory=self.pin_memory,
             worker_init_fn=self._seed_worker if self.num_workers > 0 else None,
         )
         test_dataloader = DataLoader(
@@ -486,7 +491,7 @@ class Estimator:
             ),
             num_workers=self.num_workers,
             persistent_workers=self.persistent_workers,
-            pin_memory=True,
+            pin_memory=self.pin_memory,
             worker_init_fn=self._seed_worker if self.num_workers > 0 else None,
         )
         self._maybe_run_data_dependent_init(train_dataloader)
@@ -686,7 +691,7 @@ class Estimator:
             ),
             num_workers=self.num_workers,
             persistent_workers=self.persistent_workers,
-            pin_memory=True,
+            pin_memory=self.pin_memory,
             worker_init_fn=self._seed_worker if self.num_workers > 0 else None,
         )
         self._maybe_run_data_dependent_init(dataloader)
@@ -740,7 +745,7 @@ class Estimator:
             ),
             num_workers=self.num_workers,
             persistent_workers=self.persistent_workers,
-            pin_memory=True,
+            pin_memory=self.pin_memory,
             worker_init_fn=self._seed_worker if self.num_workers > 0 else None,
         )
         with torch.no_grad():

--- a/inst/python/LrFinder.py
+++ b/inst/python/LrFinder.py
@@ -3,10 +3,10 @@ import random
 
 import torch
 from torch.optim.lr_scheduler import _LRScheduler
-from tqdm import tqdm
 
 from Estimator import batch_to_device
 from gpu_memory_cleanup import memory_cleanup
+from progress import tqdm
 
 
 class ExponentialSchedulerPerBatch(_LRScheduler):
@@ -118,5 +118,4 @@ def get_lr(estimator,
         memory_cleanup()
         raise e
     return lr
-
 

--- a/inst/python/progress.py
+++ b/inst/python/progress.py
@@ -1,0 +1,8 @@
+import threading
+
+from tqdm import tqdm as _tqdm
+
+
+_tqdm.set_lock(threading.RLock())
+
+tqdm = _tqdm

--- a/tests/testthat/teardown.R
+++ b/tests/testthat/teardown.R
@@ -1,0 +1,53 @@
+testEnv <- environment()
+
+closeAndromedaObject <- function(x, depth = 0L) {
+  if (depth > 3L) {
+    return(invisible())
+  }
+  if (inherits(x, "Andromeda")) {
+    try(Andromeda::close(x), silent = TRUE)
+    return(invisible())
+  }
+  if (is.list(x)) {
+    for (item in x) {
+      closeAndromedaObject(item, depth = depth + 1L)
+    }
+  }
+  invisible()
+}
+
+for (name in ls(envir = testEnv, all.names = TRUE)) {
+  try(closeAndromedaObject(get(name, envir = testEnv)), silent = TRUE)
+}
+
+objectsToRemove <- setdiff(
+  ls(envir = testEnv, all.names = TRUE),
+  c("testEnv", "closeAndromedaObject", "objectsToRemove")
+)
+rm(list = objectsToRemove, envir = testEnv)
+invisible(gc())
+
+if (
+  requireNamespace("reticulate", quietly = TRUE) &&
+    reticulate::py_available(initialize = FALSE)
+) {
+  try(
+    reticulate::py_run_string("
+import gc
+
+try:
+    import torch
+    if hasattr(torch, 'cuda'):
+        torch.cuda.empty_cache()
+    if hasattr(torch, 'mps') and hasattr(torch.mps, 'empty_cache'):
+        torch.mps.empty_cache()
+except Exception:
+    pass
+
+gc.collect()
+"),
+    silent = TRUE
+  )
+}
+
+invisible(gc())

--- a/tests/testthat/test-Estimator.R
+++ b/tests/testthat/test-Estimator.R
@@ -45,6 +45,12 @@ test_that("Estimator initialization works", {
     estimator$model_parameters,
     camelCaseToSnakeCaseNames(modelParameters)
   )
+
+  testthat::expect_true(estimator$`_should_pin_memory`("cuda"))
+  testthat::expect_true(estimator$`_should_pin_memory`("cuda:0"))
+  testthat::expect_false(estimator$`_should_pin_memory`("cpu"))
+  testthat::expect_false(estimator$`_should_pin_memory`("mps"))
+  testthat::expect_false(estimator$pin_memory)
 })
 
 test_that("Estimator detects wrong inputs", {

--- a/tests/testthat/test-MultiLayerPerceptron.R
+++ b/tests/testthat/test-MultiLayerPerceptron.R
@@ -167,6 +167,7 @@ test_that("Can upload results to database", {
     server = sqliteFile
   )
   conn <- DatabaseConnector::connect(connectionDetails = connectionDetails)
+  withr::defer(DatabaseConnector::disconnect(conn))
   targetDialect <- "sqlite"
 
   # check the results table is populated

--- a/tests/testthat/test-ResNet.R
+++ b/tests/testthat/test-ResNet.R
@@ -203,6 +203,7 @@ test_that("Can upload results to database", {
     server = sqliteFile
   )
   conn <- DatabaseConnector::connect(connectionDetails = connectionDetails)
+  withr::defer(DatabaseConnector::disconnect(conn))
   targetDialect <- "sqlite"
 
   # check the results table is populated

--- a/tests/testthat/test-Transformer.R
+++ b/tests/testthat/test-Transformer.R
@@ -217,6 +217,11 @@ test_that("temporal transformer works", {
     population = population,
     splitSettings = PatientLevelPrediction::createDefaultSplitSetting(splitSeed = 42)
   )
+  withr::defer({
+    try(Andromeda::close(trainData$Train$covariateData), silent = TRUE)
+    try(Andromeda::close(trainData$Test$covariateData), silent = TRUE)
+    try(Andromeda::close(plpData$covariateData), silent = TRUE)
+  })
 
   settings <- setTransformer(
     numBlocks = 1,


### PR DESCRIPTION
## Summary
- only enable PyTorch DataLoader pinned memory for CUDA devices
- keep pinned memory disabled for CPU/MPS devices such as macOS ARM runners
- cover CUDA, CPU, and MPS pin-memory behavior in estimator tests

## Testing
- python3 -m py_compile inst/python/Estimator.py
- git diff --check
- Rscript -e 'parse("tests/testthat/test-Estimator.R"); cat("R parse OK\\n")'\n\nFull estimator tests were not run locally because PatientLevelPrediction >= 6.5.0 is not installed in the local R library.