### PR TITLE
docs: refresh runtime guidance

### DIFF
--- a/.github/workflows/R_CDM_check_hades.yaml
+++ b/.github/workflows/R_CDM_check_hades.yaml
@@ -3,7 +3,8 @@
 on:
   push:
     branches:
-      - '**'
+      - develop
+      - main
   pull_request:
     branches:
       - '**'
@@ -20,10 +21,10 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: windows-latest, r: 'release', python: '3.12', torch: '2.10.0'}
-          - {os: macOS-latest, r: 'release', python: '3.12', torch: '2.10.0'}
-          - {os: ubuntu-24.04, r: 'release', python: '3.12', torch: '2.10.0', rspm: "https://packagemanager.rstudio.com/cran/__linux__/noble/latest"}
-          - {os: ubuntu-24.04, r: 'release', python: '3.10', torch: 'latest', rspm: "https://packagemanager.rstudio.com/cran/__linux__/noble/latest"}
+          - {os: windows-latest, r: 'release', python: '3.14', torch: '2.12.1'}
+          - {os: macOS-latest, r: 'release', python: '3.14', torch: '2.12.1'}
+          - {os: ubuntu-24.04, r: 'release', python: '3.14', torch: '2.12.1', rspm: "https://packagemanager.rstudio.com/cran/__linux__/noble/latest"}
+          - {os: ubuntu-24.04, r: 'release', python: '3.14', torch: 'latest', rspm: "https://packagemanager.rstudio.com/cran/__linux__/noble/latest"}
 
     env:
       GITHUB_PAT: ${{ secrets.GH_TOKEN }}
@@ -58,7 +59,7 @@ jobs:
 
       - uses: r-lib/actions/setup-pandoc@v2
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.config.python }}
 

--- a/.github/workflows/R_CMD_check_main_weekly.yaml
+++ b/.github/workflows/R_CMD_check_main_weekly.yaml
@@ -31,15 +31,15 @@ jobs:
         with:
           r-version: ${{ matrix.config.r }}
           
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
-          python-version: '3.12'
+          python-version: '3.14'
 
       - name: Install the latest version of uv
         uses: astral-sh/setup-uv@v4
         with:
           version: "latest"
-          python-version: "3.12"
+          python-version: "3.14"
       
       - uses: r-lib/actions/setup-tinytex@v2
 
@@ -53,7 +53,7 @@ jobs:
       - name: setup r-reticulate venv
         run: |
           uv pip install polars tqdm pyarrow duckdb nvidia-ml-py numpy
-          uv pip install "torch==2.10.0" --index https://download.pytorch.org/whl/cpu/
+          uv pip install "torch==2.12.1" --index https://download.pytorch.org/whl/cpu/
 
       - uses: r-lib/actions/check-r-package@v2
         with:

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+DeepPatientLevelPrediction 2.3.0.9999
+======================
+
+Documentation and CI
+- Update CI and installation guidance to validate the recommended Python environment with Python 3.14 and torch 2.12.1.
+- Limit push-triggered R CMD checks to `develop` and `main` while keeping pull request checks enabled for all branches.
+
 DeepPatientLevelPrediction 2.3.0
 ======================
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ DeepPatientLevelPrediction is an R package. It uses Python [PyTorch](https://pyt
 
 System Requirements
 ===================
-Requires R (version 4.0.0 or higher). Installation on Windows requires [RTools](http://cran.r-project.org/bin/windows/Rtools/). A CPU can be used for small examples and tests; an NVIDIA GPU is recommended for larger deep learning model development.
+Requires R (version 4.1.0 or higher). Installation on Windows requires [RTools](http://cran.r-project.org/bin/windows/Rtools/). A CPU can be used for small examples and tests; an NVIDIA GPU is recommended for larger deep learning model development.
 
 
 Getting Started

--- a/vignettes/Installing.Rmd
+++ b/vignettes/Installing.Rmd
@@ -37,7 +37,7 @@ This vignette describes how you need to install the Observational Health Data Sc
 
 Under Windows the OHDSI Deep Patient Level Prediction (DeepPLP) package requires installing:
 
--   R (<https://cran.r-project.org/> ) - (R \>= 4.0.0, but latest is recommended)
+-   R (<https://cran.r-project.org/> ) - (R \>= 4.1.0, but latest is recommended)
 -   Python - Recommend Python 3.14. Python \>= 3.10 is supported
 -   RStudio (<https://www.rstudio.com/> )
 -   Java (<http://www.java.com> )
@@ -47,7 +47,7 @@ Under Windows the OHDSI Deep Patient Level Prediction (DeepPLP) package requires
 
 Under Mac and Linux the OHDSI DeepPLP package requires installing:
 
--   R (<https://cran.r-project.org/> ) - (R \>= 4.0.0, but latest is recommended)
+-   R (<https://cran.r-project.org/> ) - (R \>= 4.1.0, but latest is recommended)
 -   Python - Recommend Python 3.14. Python \>= 3.10 is supported
 -   RStudio (<https://www.rstudio.com/> )
 -   Java (<http://www.java.com> )

--- a/vignettes/Installing.Rmd
+++ b/vignettes/Installing.Rmd
@@ -38,7 +38,7 @@ This vignette describes how you need to install the Observational Health Data Sc
 Under Windows the OHDSI Deep Patient Level Prediction (DeepPLP) package requires installing:
 
 -   R (<https://cran.r-project.org/> ) - (R \>= 4.0.0, but latest is recommended)
--   Python - Recommend Python 3.12. Python \>= 3.10 is supported
+-   Python - Recommend Python 3.14. Python \>= 3.10 is supported
 -   RStudio (<https://www.rstudio.com/> )
 -   Java (<http://www.java.com> )
 -   RTools (<https://cran.r-project.org/bin/windows/Rtools/>)
@@ -48,7 +48,7 @@ Under Windows the OHDSI Deep Patient Level Prediction (DeepPLP) package requires
 Under Mac and Linux the OHDSI DeepPLP package requires installing:
 
 -   R (<https://cran.r-project.org/> ) - (R \>= 4.0.0, but latest is recommended)
--   Python - Recommend Python 3.12. Python \>= 3.10 is supported
+-   Python - Recommend Python 3.14. Python \>= 3.10 is supported
 -   RStudio (<https://www.rstudio.com/> )
 -   Java (<http://www.java.com> )
 -   Xcode command line tools(run in terminal: xcode-select --install) [MAC USERS ONLY]
@@ -72,13 +72,13 @@ library(DeepPatientLevelPrediction)
 reticulate::py_config()
 ```
 
-Advanced users, users with strict reproducibility requirements, or users in airgapped environments can manage the Python environment themselves and tell `reticulate` which interpreter to use. One option is to create the environment with `uv` and Python 3.12:
+Advanced users, users with strict reproducibility requirements, or users in airgapped environments can manage the Python environment themselves and tell `reticulate` which interpreter to use. One option is to create the environment with `uv` and Python 3.14:
 
 ```bash
-uv python install 3.12
-uv venv --python 3.12
+uv python install 3.14
+uv venv --python 3.14
 uv pip install polars tqdm pyarrow duckdb nvidia-ml-py numpy
-uv pip install "torch==2.10.0" --index https://download.pytorch.org/whl/cpu/
+uv pip install "torch==2.12.1" --index https://download.pytorch.org/whl/cpu/
 ```
 
 The second `uv pip install` command installs the CPU build of PyTorch. If you want to train on a GPU, install the PyTorch build that matches your CUDA setup instead.
@@ -99,7 +99,7 @@ RETICULATE_PYTHON="C:/path/to/project/.venv/Scripts/python.exe"
 
 Then restart your R session.
 
-Python 3.9 is end-of-life and should not be used. Python 3.10 is still supported, but Python 3.12 is recommended.
+Python 3.9 is end-of-life and should not be used. Python 3.10 is still supported, but Python 3.14 is recommended.
 
 ## Installing DeepPatientLevelPrediction using remotes
 


### PR DESCRIPTION
## Summary
- add an unreleased NEWS entry for the Python 3.14 / torch 2.12 CI update
- align README and installation guide with DESCRIPTION's R >= 4.1.0 requirement

## Validation
- scanned active docs for stale Python 3.12 / torch 2.10 / R 4.0 references
- parsed workflow YAML locally
- ran git diff --check