### PR TITLE
docs: refresh runtime guidance

### DIFF
--- a/.github/workflows/R_CDM_check_hades.yaml
+++ b/.github/workflows/R_CDM_check_hades.yaml
@@ -88,7 +88,11 @@ jobs:
       - name: setup r-reticulate venv
         shell: bash
         run: |
-          uv pip install polars tqdm pyarrow duckdb nvidia-ml-py numpy
+          if [ "${RUNNER_OS}" = "macOS" ]; then
+            uv pip install polars tqdm pyarrow "duckdb==1.5.2" nvidia-ml-py numpy
+          else
+            uv pip install polars tqdm pyarrow duckdb nvidia-ml-py numpy
+          fi
           if [ "${{ matrix.config.torch }}" = "latest" ]; then
             uv pip install torch --index https://download.pytorch.org/whl/cpu/
           else

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,20 @@
+DeepPatientLevelPrediction 2.3.0.9999
+======================
+
+New features
+- Add hyperparameter tuning support for RealMLP.
+
+Bug fixes
+- Keep temporal dataset `feature_ids`, `feature_values`, and `time_ids` aligned when multiple features share the same time ID.
+
+Documentation and CI
+- Refresh RealMLP examples for current grid/random tuning behavior.
+- Add a dedicated temporal transformer vignette.
+- Update CI and installation guidance to validate the recommended Python environment with Python 3.14 and torch 2.12.1.
+- Pin Python duckdb to 1.5.2 on macOS CI to avoid intermittent shutdown segfaults.
+- Limit push-triggered R CMD checks to `develop` and `main` while keeping pull request checks enabled for all branches.
+- Refresh vignette wording and examples for current runtime guidance.
+
 DeepPatientLevelPrediction 2.3.0
 ======================
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ DeepPatientLevelPrediction is an R package. It uses Python [PyTorch](https://pyt
 
 System Requirements
 ===================
-Requires R (version 4.0.0 or higher). Installation on Windows requires [RTools](http://cran.r-project.org/bin/windows/Rtools/). A CPU can be used for small examples and tests; an NVIDIA GPU is recommended for larger deep learning model development.
+Requires R (version 4.1.0 or higher). Installation on Windows requires [RTools](http://cran.r-project.org/bin/windows/Rtools/). A CPU can be used for small examples and tests; an NVIDIA GPU is recommended for larger deep learning model development.
 
 
 Getting Started
@@ -37,6 +37,8 @@ Getting Started
 - Python dependencies are managed through `reticulate` when the package is loaded or used. Advanced users can point `RETICULATE_PYTHON` at a prebuilt environment for offline or controlled deployments.
 - Please read the main vignette for the package:
 [Building Deep Learning Models](https://ohdsi.github.io/DeepPatientLevelPrediction/articles/BuildingDeepModels.html)
+- Temporal transformer models are covered in:
+[Building Temporal Transformer Models](https://ohdsi.github.io/DeepPatientLevelPrediction/articles/TemporalTransformer.html)
 
 User Documentation
 ==================

--- a/vignettes/BuildingDeepModels.Rmd
+++ b/vignettes/BuildingDeepModels.Rmd
@@ -155,8 +155,8 @@ model's parameters to reduce the error.
 
 #### Set Function
 
-To use the package to fit a MLP model you can use the `setMultiLayerPerceptron()`
-function to specify the hyper-parameter settings for the MLP.
+To use the package to fit an MLP model you can use the `setMultiLayerPerceptron()`
+function to specify the hyperparameter settings for the MLP.
 
 #### Inputs
 
@@ -345,7 +345,7 @@ since each input only includes one option.
 
 ```{r, eval=FALSE}
 
-resset <- setResNet(
+resnetSettings <- setResNet(
   numLayers = c(2L),
   sizeHidden = c(32L),
   hiddenFactor = c(2L),
@@ -365,7 +365,7 @@ resset <- setResNet(
 resResult <- PatientLevelPrediction::runPlp(
     plpData = plpData,
     outcomeId = 3,
-    modelSettings = resset,
+    modelSettings = resnetSettings,
     analysisId = 'ResNet',
     analysisName = 'Testing ResNet',
     populationSettings = populationSettings,
@@ -397,7 +397,9 @@ Like the other model setting helpers, `setRealMLP()` can be called with
 one value per argument for a fixed model configuration, or with multiple
 values for tunable parameters such as `numLayers`, `sizeHidden`,
 `dropout`, and `sizeEmbedding` to run a hyperparameter or sensitivity
-search.
+search. By default, RealMLP uses grid search over the supplied values.
+Set `hyperParamSearch = "random"` and `randomSample` to sample from the
+expanded grid instead.
 
 ### Example Code
 
@@ -431,6 +433,23 @@ realMlpResult <- PatientLevelPrediction::runPlp(
   )
 ```
 
+For example, the following settings sample four RealMLP configurations
+from the expanded grid:
+
+```{r, eval=FALSE}
+
+modelSettings <- setRealMLP(
+  numLayers = c(2L, 3L),
+  sizeHidden = c(128L, 256L),
+  dropout = c(0.1, 0.2),
+  numericEmbeddingMode = c("scale", "pbld"),
+  hyperParamSearch = "random",
+  randomSample = 4L,
+  randomSampleSeed = 42L,
+  device = "cpu"
+)
+```
+
 ## Transformer
 
 ### Overall concept
@@ -446,9 +465,13 @@ data from this [paper](https://arxiv.org/abs/2106.11959).
 This architecture is computationally expensive and scales badly with
 longer sequence length. In this case the sequence is the amount of
 features each patient has. Users need to be aware of how many features
-they are feeding to the model since this will effect the computation
+they are feeding to the model since this will affect the computation
 time heavily. This is something you control in `FeatureExtraction` when
 you create your `covariateSettings`.
+
+This section describes the non-temporal transformer. For transformer
+models using temporal sequence covariates, see the temporal transformer
+vignette.
 
 ### Examples
 

--- a/vignettes/FirstModel.Rmd
+++ b/vignettes/FirstModel.Rmd
@@ -29,13 +29,13 @@ knitr::opts_chunk$set(echo = TRUE)
 
 ## Introduction
 
-This vignette describes how you can develop your first deep learning model using the deepPLP package on OMOP-CDM data.
+This vignette describes how you can develop your first deep learning model using the DeepPLP package on OMOP-CDM data.
 
 First make sure you have everything installed correctly by following the [installation guide](https://ohdsi.github.io/DeepPatientLevelPrediction/articles/Installing.html)
 
 ## The data
 
-Since there is no publicly available data we use a nifty little package called [Eunomia](https://github.com/OHDSI/Eunomia) which provides us with synthetic data in the OMOP-CDM.
+Since there is no publicly available data, we use [Eunomia](https://github.com/OHDSI/Eunomia), which provides synthetic data in the OMOP CDM.
 
 It can be installed with:
 
@@ -43,20 +43,20 @@ It can be installed with:
 install.packages('Eunomia')
 ```
 
-To start with we have to define our cohorts of interest and extract a so called plpData object with the features we want to use.
+To start with, we have to define our cohorts of interest and extract a `plpData` object with the features we want to use.
 
-In Eunomia the cohorts have already been defined but we need to create them. This we can do by running:
+In Eunomia the cohorts have already been defined, but we need to create them. We can do this by running:
 
 ```{r, echo = TRUE, message = FALSE, warning = FALSE,tidy=FALSE,eval=FALSE}
 connectionDetails <- Eunomia::getEunomiaConnectionDetails()
 Eunomia::createCohorts(connectionDetails)
 ```
 
-The first line gets the Eunomia connection details. The Eunomia data is stored in a sqlite database. The second line creates the cohorts. You should see output confirming that three target cohorts have been created, consisting of users of certain medications and one outcome cohort of gastrointestinal bleeding.
+The first line gets the Eunomia connection details. The Eunomia data is stored in a SQLite database. The second line creates the cohorts. You should see output confirming that three target cohorts have been created, consisting of users of certain medications and one outcome cohort of gastrointestinal bleeding.
 
 ## Our settings
 
-We define our covariate settings using [FeatureExtraction](https://github.com/OHDSI/FeatureExtraction)
+We define our covariate settings using [FeatureExtraction](https://github.com/OHDSI/FeatureExtraction).
 
 ```{r, echo = TRUE, message = FALSE, warning = FALSE,tidy=FALSE,eval=FALSE}
 covariateSettings <- FeatureExtraction::createCovariateSettings(
@@ -104,7 +104,7 @@ When defining our study population we define the time-at-risk. Which is when we 
 
 ## The model
 
-Now it's time to define our deep learning model. It can be daunting for those not familiar with deep learning to define their first model since the models are very flexible and have many hyperparameters to define for your model architecture. To help with this `deepPLP` has helper functions with a sensible set of hyperparameters for testing. Best practice is though to do an extensive hyperparameter tuning step using cross validation.
+Now it's time to define our deep learning model. It can be daunting for those not familiar with deep learning to define their first model since the models are very flexible and have many hyperparameters to define for your model architecture. To help with this, DeepPLP has helper functions with a sensible set of hyperparameters for testing. Best practice is still to do an extensive hyperparameter tuning step using cross validation.
 
 We will use a simple ResNet for our example. ResNets use skip connections between layers to support deeper models without overfitting as quickly. The default ResNet is a 6 layer model with 512 neurons per layer.
 

--- a/vignettes/Installing.Rmd
+++ b/vignettes/Installing.Rmd
@@ -37,7 +37,7 @@ This vignette describes how you need to install the Observational Health Data Sc
 
 Under Windows the OHDSI Deep Patient Level Prediction (DeepPLP) package requires installing:
 
--   R (<https://cran.r-project.org/> ) - (R \>= 4.0.0, but latest is recommended)
+-   R (<https://cran.r-project.org/> ) - (R \>= 4.1.0, but latest is recommended)
 -   Python - Recommend Python 3.14. Python \>= 3.10 is supported
 -   RStudio (<https://www.rstudio.com/> )
 -   Java (<http://www.java.com> )
@@ -47,7 +47,7 @@ Under Windows the OHDSI Deep Patient Level Prediction (DeepPLP) package requires
 
 Under Mac and Linux the OHDSI DeepPLP package requires installing:
 
--   R (<https://cran.r-project.org/> ) - (R \>= 4.0.0, but latest is recommended)
+-   R (<https://cran.r-project.org/> ) - (R \>= 4.1.0, but latest is recommended)
 -   Python - Recommend Python 3.14. Python \>= 3.10 is supported
 -   RStudio (<https://www.rstudio.com/> )
 -   Java (<http://www.java.com> )

--- a/vignettes/TemporalTransformer.Rmd
+++ b/vignettes/TemporalTransformer.Rmd
@@ -1,0 +1,184 @@
+---
+title: "Building Temporal Transformer Models"
+author: "Egill Fridgeirsson"
+date: '`r Sys.Date()`'
+header-includes:
+  - \usepackage{fancyhdr}
+  - \pagestyle{fancy}
+  - \fancyhead{}
+  - \fancyfoot[LE,RO]{\thepage}
+  - \renewcommand{\headrulewidth}{0.4pt}
+  - \renewcommand{\footrulewidth}{0.4pt}
+  - \fancyfoot[CO,CE]{PatientLevelPrediction Package Version `r  utils::packageVersion("PatientLevelPrediction")`}
+  - \fancyfoot[CO,CE]{DeepPatientLevelPrediction Package Version `r  utils::packageVersion("DeepPatientLevelPrediction")`}
+output:
+  html_document:
+    number_sections: yes
+    toc: yes
+editor_options:
+  markdown:
+    wrap: 72
+---
+
+```{=html}
+<!--
+%\VignetteEngine{knitr::rmarkdown}
+%\VignetteIndexEntry{Building Temporal Transformer Models}
+-->
+```
+```{r setup, include=FALSE}
+knitr::opts_chunk$set(echo = TRUE)
+```
+
+# Introduction
+
+This vignette shows how to build a temporal transformer model with
+`DeepPatientLevelPrediction`. It assumes you are already familiar with
+building a regular `PatientLevelPrediction` analysis and have read the
+first model vignette.
+
+The temporal transformer uses sequence data instead of the usual
+two-dimensional patient-by-feature matrix. Each covariate record must
+include a `timeId` so the model can receive feature IDs, feature values,
+and the time step for each feature. The temporal sequence is created
+when you extract `plpData`.
+
+# Create Temporal Data
+
+Temporal transformer models need `plpData` built with temporal sequence
+covariate settings. The example below extracts demographic and condition
+features over the one year window before index.
+
+```{r, eval=FALSE}
+temporalCovariateSettings <-
+  FeatureExtraction::createTemporalSequenceCovariateSettings(
+    useDemographicsAge = TRUE,
+    useDemographicsGender = TRUE,
+    useConditionOccurrence = TRUE,
+    sequenceStartDay = -365,
+    sequenceEndDay = -1
+  )
+
+temporalPlpData <- PatientLevelPrediction::getPlpData(
+  databaseDetails = databaseDetails,
+  restrictPlpDataSettings =
+    PatientLevelPrediction::createRestrictPlpDataSettings(),
+  covariateSettings = temporalCovariateSettings
+)
+```
+
+Use the same `databaseDetails`, target and outcome cohort definitions,
+and `populationSettings` that you would use for a regular PLP analysis.
+
+# Configure The Model
+
+Use `setTransformer()` with `temporal = TRUE` to enable the temporal
+path. Temporal behavior is controlled through `temporalSettings`.
+
+The most important settings are:
+
+- `maxSequenceLength`: the maximum number of time-ordered feature
+  records per person. Use an integer for a fixed length or `"max"` to
+  use the maximum sequence length in the data.
+- `truncation`: how to truncate sequences longer than
+  `maxSequenceLength`. Currently only `"tail"` is supported.
+- `timeTokens`: whether to include explicit time tokens in the model
+  input.
+- `positionalEncoding`: the positional encoding used by the transformer.
+  This can be a character value such as `"SinusoidalPE"` or a list with
+  the encoding name and settings.
+
+For reproducible model definitions, set `temporalSettings` explicitly
+instead of relying on defaults.
+
+```{r, eval=FALSE}
+modelSettings <- DeepPatientLevelPrediction::setTransformer(
+  numBlocks = 1L,
+  dimToken = 8L,
+  dimOut = 1L,
+  numHeads = 2L,
+  attDropout = 0.0,
+  ffnDropout = 0.2,
+  dimHidden = 32L,
+  temporal = TRUE,
+  temporalSettings = list(
+    positionalEncoding = list(
+      name = "SinusoidalPE",
+      dropout = 0.1
+    ),
+    maxSequenceLength = 256L,
+    truncation = "tail",
+    timeTokens = FALSE
+  ),
+  estimatorSettings = DeepPatientLevelPrediction::setEstimator(
+    learningRate = 3e-4,
+    weightDecay = 1e-6,
+    batchSize = 64L,
+    epochs = 3L,
+    device = "cpu"
+  ),
+  randomSample = 1L
+)
+```
+
+Use `device = "cuda"` or a specific CUDA device such as `"cuda:0"` when
+you have an NVIDIA GPU available.
+
+# Run The Analysis
+
+The temporal transformer is passed to `PatientLevelPrediction::runPlp()`
+in the same way as other DeepPLP model settings.
+
+```{r, eval=FALSE}
+temporalTransformerResult <- PatientLevelPrediction::runPlp(
+  plpData = temporalPlpData,
+  outcomeId = 3,
+  modelSettings = modelSettings,
+  analysisId = "TemporalTransformer",
+  analysisName = "Testing temporal transformer",
+  populationSettings = populationSettings,
+  splitSettings = PatientLevelPrediction::createDefaultSplitSetting(
+    splitSeed = 42
+  ),
+  preprocessSettings = PatientLevelPrediction::createPreprocessSettings(),
+  executeSettings = PatientLevelPrediction::createExecuteSettings(
+    runSplitData = TRUE,
+    runSampleData = FALSE,
+    runFeatureEngineering = FALSE,
+    runPreprocessData = TRUE,
+    runModelDevelopment = TRUE,
+    runCovariateSummary = FALSE
+  ),
+  saveDirectory = file.path(getwd(), "TemporalTransformer")
+)
+```
+
+# Practical Notes
+
+Temporal transformers are usually more expensive than non-temporal
+models because attention scales with sequence length. Start with a small
+`maxSequenceLength`, a small number of blocks, and a CPU-compatible test
+run. Increase model size and move to CUDA only after the data extraction
+and model wiring are working.
+
+The order and density of the extracted temporal features matter. If the
+model is too slow or uses too much memory, reduce the number of temporal
+covariates in `FeatureExtraction`, shorten the time window, or lower
+`maxSequenceLength`.
+
+# Acknowledgments
+
+Considerable work has been dedicated to provide the
+`DeepPatientLevelPrediction` package.
+
+```{r tidy=TRUE,eval=TRUE}
+citation("DeepPatientLevelPrediction")
+```
+
+**Please reference this paper if you use the PLP Package in your work:**
+
+[Reps JM, Schuemie MJ, Suchard MA, Ryan PB, Rijnbeek PR. Design and
+implementation of a standardized framework to generate and evaluate
+patient-level prediction models using observational healthcare data. J
+Am Med Inform Assoc.
+2018;25(8):969-975.](http://dx.doi.org/10.1093/jamia/ocy032)

--- a/vignettes/TransferLearning.Rmd
+++ b/vignettes/TransferLearning.Rmd
@@ -43,12 +43,12 @@ connectionDetails <- Eunomia::getEunomiaConnectionDetails()
 Eunomia::createCohorts(connectionDetails)
 ```
 
-The default Eunomia package includes four cohorts. Gastrointestinal bleeding (`GiBleed`) and use of three different drugs, `diclofenac`, `NSAIDS` and `celecoxib`. Usually then we would use one of three drug cohorts as our target cohort and then predict the risk of gastrointestinal bleeding. The `cohort_definition_ids` of these are: `celecoxib: 1`, `diclofenac: 2`, `GiBleed: 3` and `NSAIDS: 4`.
+The default Eunomia package includes four cohorts: gastrointestinal bleeding (`GiBleed`) and use of three different drugs, `diclofenac`, `NSAIDs`, and `celecoxib`. Usually we would use one of the drug cohorts as our target cohort and then predict the risk of gastrointestinal bleeding. The cohort definition IDs are: `celecoxib: 1`, `diclofenac: 2`, `GiBleed: 3`, and `NSAIDs: 4`.
 
-After creating the cohorts we can see that there are most patients in the `NSAIDS` cohort. We will use this cohort as our target cohort for the initial model. There are least patients in the `diclofenac` cohort (excluding `GiBleed`), so we will use this cohort as our target cohort for the transfer learning model.
+After creating the cohorts, we can see that the `NSAIDs` cohort has the most patients. We will use this cohort as our target cohort for the initial model. The `diclofenac` cohort has the fewest patients, excluding `GiBleed`, so we will use it as our target cohort for the transfer learning model.
 
 ```{r, message=FALSE, eval=FALSE}
-# create some simple covariate settings using Sex, Age and Long-term conditions and drug use in the last year.
+# Create some simple covariate settings using sex, age, and long-term conditions and drug use in the last year.
 covariateSettings <- FeatureExtraction::createCovariateSettings(
   useDemographicsGender = TRUE,
   useDemographicsAge = TRUE,
@@ -57,7 +57,7 @@ covariateSettings <- FeatureExtraction::createCovariateSettings(
   endDays = 0
 )
 
-# Information about the database. In Eunomia sqlite there is only one schema, main and the cohorts are in a table named `cohort` which is the default. 
+# Information about the database. In Eunomia SQLite there is only one schema, main, and the cohorts are in the default table named `cohort`.
 databaseDetails <- PatientLevelPrediction::createDatabaseDetails(
   connectionDetails = connectionDetails,
   cdmDatabaseId = "2", # Eunomia version used
@@ -98,11 +98,11 @@ modelSettings <- setResNet(numLayers = c(2),
 
 plpResults <- PatientLevelPrediction::runPlp(
   plpData = plpData,
-  outcomeId = 3, # 4 is the id of GiBleed
+  outcomeId = 3, # GiBleed
   modelSettings = modelSettings,
   analysisName = "Nsaids_GiBleed",
   analysisId = "1",
-  # Let's predict the risk of Gibleed in the year following start of NSAIDs use
+  # Predict the risk of GiBleed in the year following start of NSAIDs use
   populationSettings = PatientLevelPrediction::createStudyPopulationSettings(
     requireTimeAtRisk = FALSE,
     firstExposureOnly = TRUE,
@@ -115,7 +115,7 @@ plpResults <- PatientLevelPrediction::runPlp(
 
 ```
 
-This should take a few minutes on a cpu. Now that we have a model developed we can further finetune it on the `diclofenac` cohort. First we need to extract it.
+This should take a few minutes on a CPU. Now that we have a model developed, we can further finetune it on the `diclofenac` cohort. First we need to extract it.
 
 ```{r, message=FALSE, eval=FALSE}
 databaseDetails <- PatientLevelPrediction::createDatabaseDetails(
@@ -150,7 +150,7 @@ modelSettingsTransfer <- setFinetuner(modelPath = './output/1/plpResult/model',
 
 ```
 
-Currently the basic transfer learning works by loading the previously trained model and resetting it's last layer, often called the prediction head. Then it will train only the parameters in this last layer. The hope is that the other layer's have learned some generalizable representations of our data and by modifying the last layer we can mix those representations to suit the new task. 
+Currently the basic transfer learning works by loading the previously trained model and resetting its last layer, often called the prediction head. Then it will train only the parameters in this last layer. The hope is that the other layers have learned some generalizable representations of our data, and by modifying the last layer we can mix those representations to suit the new task.
 
 ```{r, message=FALSE, eval=FALSE}
 plpResultsTransfer <- PatientLevelPrediction::runPlp(
@@ -170,7 +170,7 @@ plpResultsTransfer <- PatientLevelPrediction::runPlp(
 )
 ```
 
-This should be much faster since it's only training the last layer. Unfortunately the results are bad. However this is a toy example on synthetic toy data but the process on large observational data is exactly the same. 
+This should be much faster since it only trains the last layer. The results are not expected to be good in this toy example on synthetic data, but the process on large observational data is the same.
 
 # Conclusion
 Now you have finetuned a model on a new cohort using transfer learning. This can be useful when you have a small dataset for the new task, but a large dataset for a related task or from a different database. The DeepPatientLevelPrediction package makes it easy to perform transfer learning on patient-level prediction tasks.


### PR DESCRIPTION
## Summary
- add an unreleased NEWS entry covering the current develop delta: RealMLP tuning, temporal dataset ordering, CI/runtime updates, and docs refresh
- align README and installation guide with DESCRIPTION's R >= 4.1.0 requirement
- review all vignettes against current code and refresh stale/incorrect wording, including the GiBleed outcome comment and RealMLP tuning behavior
- add a dedicated temporal transformer vignette covering temporal covariate extraction, `temporal = TRUE`, `temporalSettings`, and `runPlp()` wiring
- pin Python duckdb to 1.5.2 on macOS CI while leaving other CI lanes on the latest duckdb

## Validation
- compared origin/main..origin/develop for release-facing changes
- scanned active docs/vignettes for stale Python 3.12 / torch 2.10 / R 4.0 references
- checked `FeatureExtraction::createTemporalSequenceCovariateSettings()` arguments locally for the temporal example
- parsed R code chunks from all vignettes with knitr::purl + parse
- rendered the temporal transformer vignette locally
- ran R CMD build --no-manual
- ran git diff --check
- parsed the updated workflow YAML locally