### PR TITLE
fix(ci): remove unreleased vignette README link

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,6 @@ Getting Started
 - Python dependencies are managed through `reticulate` when the package is loaded or used. Advanced users can point `RETICULATE_PYTHON` at a prebuilt environment for offline or controlled deployments.
 - Please read the main vignette for the package:
 [Building Deep Learning Models](https://ohdsi.github.io/DeepPatientLevelPrediction/articles/BuildingDeepModels.html)
-- Temporal transformer models are covered in:
-[Building Temporal Transformer Models](https://ohdsi.github.io/DeepPatientLevelPrediction/articles/TemporalTransformer.html)
 
 User Documentation
 ==================


### PR DESCRIPTION
Removes the direct README link to the new TemporalTransformer pkgdown article until the site has been rebuilt and published. The link exists only after the release/site deploy, so the current pkgdown link-check job rejects it as a 404 on develop.

Validation:
- `lychee --base "$PWD" --root-dir "$PWD" --verbose --no-progress --accept "100..=103, 200..=299, 403" "./**/*.md" "./**/*.Rmd"`